### PR TITLE
Fix Broken URLs in Documentation

### DIFF
--- a/content/en/docs/guides/structuring-software-with-ocm.md
+++ b/content/en/docs/guides/structuring-software-with-ocm.md
@@ -14,15 +14,15 @@ weight: 200
 toc: true
 ---
 Software products are divided into logical units, which are called
-[**components**](../../specification/elements/README.md#components) in this
+[**components**](https://github.com/open-component-model/ocm-spec/tree/main/doc/specification/elements#components) in this
 specification. For example, a frontend, a backend and some
 monitoring stack. The software product itself could be seen as a
 component comprising the other three components.
 
-As a result of the development phase, [**component versions**](../../specification/elements/README.md#component-versions)
+As a result of the development phase, [**component versions**](https://github.com/open-component-model/ocm-spec/blob/main/doc/specification/elements/README.md#component-versions)
 are created, e.g. when you make a new release of a component.
 
-A component version consists of a set of technical [artifacts](../../specification/elements/README.md#artifacts),
+A component version consists of a set of technical [artifacts](https://github.com/open-component-model/ocm-spec/blob/main/doc/specification/elements/README.md#artifacts),
 e.g. docker images, helm charts, binaries, configuration data etc.
 Such artifacts are called **resources** in this specification.
 

--- a/content/en/docs/scope.md
+++ b/content/en/docs/scope.md
@@ -70,6 +70,6 @@ The core OCM does not make any assumptions about the
 - kinds of technical artifacts (e.g. docker images, helm chart, binaries etc., git sources)
 - technology how to store and access technical artifacts (e.g. as OCI artifacts in an OCI registry)
 
-OCM is a technology-agnostic specification and allows [implementations](../specification/extensionpoints/README.md) to provide support
+OCM is a technology-agnostic specification and allows [implementations](https://github.com/open-component-model/ocm-spec/blob/main/doc/specification/extensionpoints/README.md) to provide support
 for exactly those technical aspects as an extension of the basic model. The description formalism is even valid and can (at least partly)
 formally processed, if not all specified aspects are covered by an actual implementation.


### PR DESCRIPTION
Signed-off-by: Piaras Hoban <phoban01@gmail.com>

**What this PR does / why we need it**:

Fixes links to spec in documentation pages.
