### PR TITLE
Update repo URI from gardener to open-component-model

### DIFF
--- a/content/en/docs/cli-reference/get/get_credentials.md
+++ b/content/en/docs/cli-reference/get/get_credentials.md
@@ -32,7 +32,7 @@ settings and show the found credential attributes.
 
 For the following usage contexts with matchers and standard identity matchers exist:
 
-  - <code>Buildcredentials.ocm.software</code>: Gardener config credential matcher
+  - <code>Buildcredentials.ocm.software</code>: Config credential matcher
     
     It matches the <code>Buildcredentials.ocm.software</code> consumer type and additionally acts like 
     the <code>hostpath</code> type.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gardener/ocm-website
+module github.com/open-component-model/ocm-website
 
 go 1.18
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "browserslist": [
     "defaults"
   ],
-  "repository": "https://github.com/gardener/ocm",
+  "repository": "https://github.com/open-component-model/ocm",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Changes:
- Update `go.mod` with the new repo uri
- Update `package.json` to use the open-component-model org instead of gardener org
- Remove Gardener from Config credential matcher [^1]

[^1]: https://github.com/open-component-model/ocm/issues/183