### PR TITLE
refactor: use artifact instead of artefact everywhere

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,8 +1,8 @@
 ---
 title : "Open Component Model"
-description: "The Open Component Model is an open standard to describe the software artefacts which must be delivered
+description: "The Open Component Model is an open standard to describe the software artifacts which must be delivered
 for a software product."
-lead: "The Open Component Model (OCM) is an open standard to describe the software artefacts which must be delivered
+lead: "The Open Component Model (OCM) is an open standard to describe the software artifacts which must be delivered
 for a software product."
 date: 2020-10-06T08:47:36+00:00
 lastmod: 2020-10-06T08:47:36+00:00

--- a/content/en/docs/cli-reference/_index.md
+++ b/content/en/docs/cli-reference/_index.md
@@ -28,10 +28,10 @@ isCommand: false
 
 
 The Open Component Model command line client support the work with OCM
-artefacts, like Component Archives, Common Transport Archive,  
+artifacts, like Component Archives, Common Transport Archive,  
 Component Repositories, and component versions.
 
-Additionally it provides some limited support for the docker daemon, OCI artefacts and
+Additionally it provides some limited support for the docker daemon, OCI artifacts and
 registries.
 
 It can be used in two ways:
@@ -88,15 +88,15 @@ attributes are supported:
 
 - <code>github.com/mandelsoft/ocm/keeplocalblob</code> [<code>keeplocalblob</code>]: *bool*
 
-  Keep local blobs when importing OCI artefacts to OCI registries from <code>localBlob</code>
-  access methods. By default they will be expanded to OCI artefacts with the
+  Keep local blobs when importing OCI artifacts to OCI registries from <code>localBlob</code>
+  access methods. By default they will be expanded to OCI artifacts with the
   access method <code>ociRegistry</code>. If this option is set to true, they will be stored
   as local blobs, also. The access method will still be <code>localBlob</code> but with a nested
   <code>ociRegistry</code> access method for describing the global access.
 
 - <code>github.com/mandelsoft/ocm/ociuploadrepo</code> [<code>ociuploadrepo</code>]: *oci base repository ref*
 
-  Upload local OCI artefact blobs to a dedicated repository.
+  Upload local OCI artifact blobs to a dedicated repository.
 
 - <code>github.com/mandelsoft/ocm/signing</code>: *JSON*
 
@@ -134,11 +134,11 @@ attributes are supported:
 * [ocm <b>bootstrap</b>](/docs/cli/bootstrap)	 &mdash; bootstrap components
 * [ocm <b>clean</b>](/docs/cli/clean)	 &mdash; Cleanup/re-organize elements
 * [ocm <b>create</b>](/docs/cli/create)	 &mdash; Create transport or component archive
-* [ocm <b>describe</b>](/docs/cli/describe)	 &mdash; Describe artefacts
-* [ocm <b>download</b>](/docs/cli/download)	 &mdash; Download oci artefacts, resources or complete components
-* [ocm <b>get</b>](/docs/cli/get)	 &mdash; Get information about artefacts and components
+* [ocm <b>describe</b>](/docs/cli/describe)	 &mdash; Describe artifacts
+* [ocm <b>download</b>](/docs/cli/download)	 &mdash; Download oci artifacts, resources or complete components
+* [ocm <b>get</b>](/docs/cli/get)	 &mdash; Get information about artifacts and components
 * [ocm <b>show</b>](/docs/cli/show)	 &mdash; Show tags or versions
 * [ocm <b>sign</b>](/docs/cli/sign)	 &mdash; Sign components
-* [ocm <b>transfer</b>](/docs/cli/transfer)	 &mdash; Transfer artefacts or components
+* [ocm <b>transfer</b>](/docs/cli/transfer)	 &mdash; Transfer artifacts or components
 * [ocm <b>verify</b>](/docs/cli/verify)	 &mdash; Verify component version signatures
 

--- a/content/en/docs/cli-reference/add/add_references.md
+++ b/content/en/docs/cli-reference/add/add_references.md
@@ -134,7 +134,7 @@ with the field <code>type</code> in the <code>input</code> field:
 - Input type <code>docker</code>
 
   The path must denote an image tag that can be found in the local
-  docker daemon. The denoted image is packed as OCI artefact set.
+  docker daemon. The denoted image is packed as OCI artifact set.
 
   This blob type specification supports the following fields:
   - **<code>path</code>** *string*
@@ -145,7 +145,7 @@ with the field <code>type</code> in the <code>input</code> field:
   - **<code>repository</code>** *string*
 
     This OPTIONAL property can be used to specify the repository hint for the
-    generated local artefact access. It is prefixed by the component name if
+    generated local artifact access. It is prefixed by the component name if
     it does not start with slash "/".
 
 - Input type <code>dockermulti</code>
@@ -153,7 +153,7 @@ with the field <code>type</code> in the <code>input</code> field:
   This input type describes the composition of a multi-platform OCI image.
   The various variants are taken from the local docker daemon. They should be
   built with the buildx command for cross platform docker builds.
-  The denoted images, as well as the wrapping image index is packed as OCI artefact set.
+  The denoted images, as well as the wrapping image index is packed as OCI artifact set.
 
   This blob type specification supports the following fields:
   - **<code>variants</code>** *[]string*
@@ -164,7 +164,7 @@ with the field <code>type</code> in the <code>input</code> field:
   - **<code>repository</code>** *string*
 
     This OPTIONAL property can be used to specify the repository hint for the
-    generated local artefact access. It is prefixed by the component name if
+    generated local artifact access. It is prefixed by the component name if
     it does not start with slash "/".
 
 - Input type <code>file</code>
@@ -195,7 +195,7 @@ with the field <code>type</code> in the <code>input</code> field:
 
   The path must denote an helm chart archive or directory
   relative to the resources file.
-  The denoted chart is packed as an OCI artefact set.
+  The denoted chart is packed as an OCI artifact set.
   Additional provider info is taken from a file with the same name
   and the suffix <code>.prov</code>.
 
@@ -228,7 +228,7 @@ with the field <code>type</code> in the <code>input</code> field:
   - **<code>repository</code>** *string*
 
     This OPTIONAL property can be used to specify the repository hint for the
-    generated local artefact access. It is prefixed by the component name if
+    generated local artifact access. It is prefixed by the component name if
     it does not start with slash "/".
 
 - Input type <code>spiff</code>

--- a/content/en/docs/cli-reference/add/add_resources.md
+++ b/content/en/docs/cli-reference/add/add_resources.md
@@ -134,7 +134,7 @@ with the field <code>type</code> in the <code>input</code> field:
 - Input type <code>docker</code>
 
   The path must denote an image tag that can be found in the local
-  docker daemon. The denoted image is packed as OCI artefact set.
+  docker daemon. The denoted image is packed as OCI artifact set.
   
   This blob type specification supports the following fields: 
   - **<code>path</code>** *string*
@@ -145,7 +145,7 @@ with the field <code>type</code> in the <code>input</code> field:
   - **<code>repository</code>** *string*
   
     This OPTIONAL property can be used to specify the repository hint for the
-    generated local artefact access. It is prefixed by the component name if
+    generated local artifact access. It is prefixed by the component name if
     it does not start with slash "/".
 
 - Input type <code>dockermulti</code>
@@ -153,7 +153,7 @@ with the field <code>type</code> in the <code>input</code> field:
   This input type describes the composition of a multi-platform OCI image.
   The various variants are taken from the local docker daemon. They should be 
   built with the buildx command for cross platform docker builds.
-  The denoted images, as well as the wrapping image index is packed as OCI artefact set.
+  The denoted images, as well as the wrapping image index is packed as OCI artifact set.
   
   This blob type specification supports the following fields:
   - **<code>variants</code>** *[]string*
@@ -164,7 +164,7 @@ with the field <code>type</code> in the <code>input</code> field:
   - **<code>repository</code>** *string*
   
     This OPTIONAL property can be used to specify the repository hint for the
-    generated local artefact access. It is prefixed by the component name if
+    generated local artifact access. It is prefixed by the component name if
     it does not start with slash "/".
 
 - Input type <code>file</code>
@@ -195,7 +195,7 @@ with the field <code>type</code> in the <code>input</code> field:
 
   The path must denote an helm chart archive or directory
   relative to the resources file.
-  The denoted chart is packed as an OCI artefact set.
+  The denoted chart is packed as an OCI artifact set.
   Additional provider info is taken from a file with the same name
   and the suffix <code>.prov</code>.
   
@@ -228,7 +228,7 @@ with the field <code>type</code> in the <code>input</code> field:
   - **<code>repository</code>** *string*
   
     This OPTIONAL property can be used to specify the repository hint for the
-    generated local artefact access. It is prefixed by the component name if
+    generated local artifact access. It is prefixed by the component name if
     it does not start with slash "/".
 
 - Input type <code>spiff</code>

--- a/content/en/docs/cli-reference/add/add_sources.md
+++ b/content/en/docs/cli-reference/add/add_sources.md
@@ -134,7 +134,7 @@ with the field <code>type</code> in the <code>input</code> field:
 - Input type <code>docker</code>
 
   The path must denote an image tag that can be found in the local
-  docker daemon. The denoted image is packed as OCI artefact set.
+  docker daemon. The denoted image is packed as OCI artifact set.
   
   This blob type specification supports the following fields: 
   - **<code>path</code>** *string*
@@ -145,7 +145,7 @@ with the field <code>type</code> in the <code>input</code> field:
   - **<code>repository</code>** *string*
   
     This OPTIONAL property can be used to specify the repository hint for the
-    generated local artefact access. It is prefixed by the component name if
+    generated local artifact access. It is prefixed by the component name if
     it does not start with slash "/".
 
 - Input type <code>dockermulti</code>
@@ -153,7 +153,7 @@ with the field <code>type</code> in the <code>input</code> field:
   This input type describes the composition of a multi-platform OCI image.
   The various variants are taken from the local docker daemon. They should be 
   built with the buildx command for cross platform docker builds.
-  The denoted images, as well as the wrapping image index is packed as OCI artefact set.
+  The denoted images, as well as the wrapping image index is packed as OCI artifact set.
   
   This blob type specification supports the following fields:
   - **<code>variants</code>** *[]string*
@@ -164,7 +164,7 @@ with the field <code>type</code> in the <code>input</code> field:
   - **<code>repository</code>** *string*
   
     This OPTIONAL property can be used to specify the repository hint for the
-    generated local artefact access. It is prefixed by the component name if
+    generated local artifact access. It is prefixed by the component name if
     it does not start with slash "/".
 
 - Input type <code>file</code>
@@ -195,7 +195,7 @@ with the field <code>type</code> in the <code>input</code> field:
 
   The path must denote an helm chart archive or directory
   relative to the resources file.
-  The denoted chart is packed as an OCI artefact set.
+  The denoted chart is packed as an OCI artifact set.
   Additional provider info is taken from a file with the same name
   and the suffix <code>.prov</code>.
   
@@ -228,7 +228,7 @@ with the field <code>type</code> in the <code>input</code> field:
   - **<code>repository</code>** *string*
   
     This OPTIONAL property can be used to specify the repository hint for the
-    generated local artefact access. It is prefixed by the component name if
+    generated local artifact access. It is prefixed by the component name if
     it does not start with slash "/".
 
 - Input type <code>spiff</code>

--- a/content/en/docs/cli-reference/bootstrap/bootstrap_componentversions.md
+++ b/content/en/docs/cli-reference/bootstrap/bootstrap_componentversions.md
@@ -93,7 +93,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`

--- a/content/en/docs/cli-reference/create/create_transportarchive.md
+++ b/content/en/docs/cli-reference/create/create_transportarchive.md
@@ -29,7 +29,7 @@ ocm create transportarchive [<options>] <path>
 
 
 Create a new empty OCM/OCI transport archive. This might be either a directory prepared
-to host artefact content or a tar/tgz file.
+to host artifact content or a tar/tgz file.
 
 
 ### See Also

--- a/content/en/docs/cli-reference/describe/_index.md
+++ b/content/en/docs/cli-reference/describe/_index.md
@@ -29,5 +29,5 @@ ocm describe [<options>] <sub command> ...
 
 ##### Sub Commands
 
-* [ocm describe <b>artefacts</b>](/docs/cli/describe/artefacts)	 &mdash; describe artefact version
+* [ocm describe <b>artifacts</b>](/docs/cli/describe/artifacts)	 &mdash; describe artifact version
 

--- a/content/en/docs/cli-reference/describe/describe_artifacts.md
+++ b/content/en/docs/cli-reference/describe/describe_artifacts.md
@@ -1,39 +1,39 @@
 ---
-title: artefacts
-name: get artefacts
-url: /docs/cli/get/artefacts/
+title: artifacts
+name: describe artifacts
+url: /docs/cli/describe/artifacts/
 date: 2022-10-19T11:39:28+01:00
 draft: false
 images: []
 menu:
   docs:
-    parent: get
+    parent: describe
 toc: true
 isCommand: true
 ---
 ### Usage
 
 ```
-ocm get artefacts [<options>] {<artefact-reference>}
+ocm describe artifacts [<options>] {<artifact-reference>}
 ```
 
 ### Options
 
 ```
-  -a, --attached           show attached artefacts
-  -h, --help               help for artefacts
-  -o, --output string      output mode (JSON, json, tree, wide, yaml)
-  -r, --recursive          follow index nesting
-      --repo string        repository name or spec
-  -s, --sort stringArray   sort fields
+  -h, --help            help for artifacts
+      --layerfiles      list layer files
+  -o, --output string   output mode (JSON, json, yaml)
+      --repo string     repository name or spec
 ```
 
 ### Description
 
 
-Get lists all artefact versions specified, if only a repository is specified
-all tagged artefacts are listed.
-	
+Describe lists all artifact versions specified, if only a repository is specified
+all tagged artifacts are listed.
+Per version a detailed, potentially recursive description is printed.
+
+
 If the repository/registry option is specified, the given names are interpreted
 relative to the specified registry using the syntax
 
@@ -42,7 +42,7 @@ relative to the specified registry using the syntax
 </center>
 
 If no <code>--repo</code> option is specified the given names are interpreted 
-as extended OCI artefact references.
+as extended OCI artifact references.
 
 <center>
     <pre>[&lt;repo type>::]&lt;host>[:&lt;port>]/&lt;OCI repository name>[:&lt;tag>][@&lt;digest>]</pre>
@@ -59,7 +59,7 @@ For the *Common Transport Format* the types <code>directory</code>,
 
 Using the JSON variant any repository type supported by the 
 linked library can be used:
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -67,14 +67,10 @@ linked library can be used:
 - `oci`
 - `ociRegistry`
 
-With the option <code>--recursive</code> the complete reference tree of a index is traversed.
-
 With the option <code>--output</code> the output mode can be selected.
 The following modes are supported:
  - JSON
  - json
- - tree
- - wide
  - yaml
 
 
@@ -82,12 +78,12 @@ The following modes are supported:
 
 ```
 
-$ ocm get artefact ghcr.io/mandelsoft/kubelink
-$ ocm get artefact --repo OCIRegistry:ghcr.io mandelsoft/kubelink
+$ ocm describe artifact ghcr.io/mandelsoft/kubelink
+$ ocm describe artifact --repo OCIRegistry:ghcr.io mandelsoft/kubelink
 
 ```
 
 ### See Also
 
-* [ocm get](/docs/cli/get)	 &mdash; Get information about artefacts and components
+* [ocm describe](/docs/cli/describe)	 &mdash; Describe artifacts
 

--- a/content/en/docs/cli-reference/download/_index.md
+++ b/content/en/docs/cli-reference/download/_index.md
@@ -29,7 +29,7 @@ ocm download [<options>] <sub command> ...
 
 ##### Sub Commands
 
-* [ocm download <b>artefacts</b>](/docs/cli/download/artefacts)	 &mdash; download oci artefacts
+* [ocm download <b>artifacts</b>](/docs/cli/download/artifacts)	 &mdash; download oci artifacts
 * [ocm download <b>componentversions</b>](/docs/cli/download/componentversions)	 &mdash; download ocm component versions
 * [ocm download <b>resources</b>](/docs/cli/download/resources)	 &mdash; download resources of a component version
 

--- a/content/en/docs/cli-reference/download/download_artifacts.md
+++ b/content/en/docs/cli-reference/download/download_artifacts.md
@@ -1,7 +1,7 @@
 ---
-title: artefacts
-name: download artefacts
-url: /docs/cli/download/artefacts/
+title: artifacts
+name: download artifacts
+url: /docs/cli/download/artifacts/
 date: 2022-10-19T11:39:28+01:00
 draft: false
 images: []
@@ -14,13 +14,13 @@ isCommand: true
 ### Usage
 
 ```
-ocm download artefacts [<options>]  {<artefact>} 
+ocm download artifacts [<options>]  {<artifact>} 
 ```
 
 ### Options
 
 ```
-  -h, --help             help for artefacts
+  -h, --help             help for artifacts
   -O, --outfile string   output file or directory
       --repo string      repository name or spec
   -t, --type string      archive format (directory, tar, tgz) (default "directory")
@@ -29,10 +29,10 @@ ocm download artefacts [<options>]  {<artefact>}
 ### Description
 
 
-Download artefacts from an OCI registry. The result is stored in
-artefact set format, without the repository part
+Download artifacts from an OCI registry. The result is stored in
+artifact set format, without the repository part
 
-The files are named according to the artefact repository name.
+The files are named according to the artifact repository name.
 
 If the repository/registry option is specified, the given names are interpreted
 relative to the specified registry using the syntax
@@ -42,7 +42,7 @@ relative to the specified registry using the syntax
 </center>
 
 If no <code>--repo</code> option is specified the given names are interpreted 
-as extended OCI artefact references.
+as extended OCI artifact references.
 
 <center>
     <pre>[&lt;repo type>::]&lt;host>[:&lt;port>]/&lt;OCI repository name>[:&lt;tag>][@&lt;digest>]</pre>
@@ -59,7 +59,7 @@ For the *Common Transport Format* the types <code>directory</code>,
 
 Using the JSON variant any repository type supported by the 
 linked library can be used:
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -77,5 +77,5 @@ The default format is <code>directory</code>.
 
 ### See Also
 
-* [ocm download](/docs/cli/download)	 &mdash; Download oci artefacts, resources or complete components
+* [ocm download](/docs/cli/download)	 &mdash; Download oci artifacts, resources or complete components
 

--- a/content/en/docs/cli-reference/download/download_componentversions.md
+++ b/content/en/docs/cli-reference/download/download_componentversions.md
@@ -71,7 +71,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -89,5 +89,5 @@ The default format is <code>directory</code>.
 
 ### See Also
 
-* [ocm download](/docs/cli/download)	 &mdash; Download oci artefacts, resources or complete components
+* [ocm download](/docs/cli/download)	 &mdash; Download oci artifacts, resources or complete components
 

--- a/content/en/docs/cli-reference/download/download_resources.md
+++ b/content/en/docs/cli-reference/download/download_resources.md
@@ -95,7 +95,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -104,7 +104,7 @@ OCI Repository types (using standard component repository to OCI mapping):
 - `ociRegistry`
 
 The library supports some downloads with semantics based on resource types. For example a helm chart
-can be download directly as helm chart archive, even if stored as OCI artefact.
+can be download directly as helm chart archive, even if stored as OCI artifact.
 This is handled by download handler. Their usage can be enabled with the <code>--download-handlers</code>
 option. Otherwise the resource as returned by the access method is stored.
 
@@ -123,5 +123,5 @@ references.
 
 ### See Also
 
-* [ocm download](/docs/cli/download)	 &mdash; Download oci artefacts, resources or complete components
+* [ocm download](/docs/cli/download)	 &mdash; Download oci artifacts, resources or complete components
 

--- a/content/en/docs/cli-reference/get/_index.md
+++ b/content/en/docs/cli-reference/get/_index.md
@@ -29,7 +29,7 @@ ocm get [<options>] <sub command> ...
 
 ##### Sub Commands
 
-* [ocm get <b>artefacts</b>](/docs/cli/get/artefacts)	 &mdash; get artefact version
+* [ocm get <b>artifacts</b>](/docs/cli/get/artifacts)	 &mdash; get artifact version
 * [ocm get <b>componentversions</b>](/docs/cli/get/componentversions)	 &mdash; get component version
 * [ocm get <b>credentials</b>](/docs/cli/get/credentials)	 &mdash; Get credentials for a dedicated consumer spec
 * [ocm get <b>references</b>](/docs/cli/get/references)	 &mdash; get references of a component version

--- a/content/en/docs/cli-reference/get/get_artifacts.md
+++ b/content/en/docs/cli-reference/get/get_artifacts.md
@@ -1,39 +1,39 @@
 ---
-title: artefacts
-name: describe artefacts
-url: /docs/cli/describe/artefacts/
+title: artifacts
+name: get artifacts
+url: /docs/cli/get/artifacts/
 date: 2022-10-19T11:39:28+01:00
 draft: false
 images: []
 menu:
   docs:
-    parent: describe
+    parent: get
 toc: true
 isCommand: true
 ---
 ### Usage
 
 ```
-ocm describe artefacts [<options>] {<artefact-reference>}
+ocm get artifacts [<options>] {<artifact-reference>}
 ```
 
 ### Options
 
 ```
-  -h, --help            help for artefacts
-      --layerfiles      list layer files
-  -o, --output string   output mode (JSON, json, yaml)
-      --repo string     repository name or spec
+  -a, --attached           show attached artifacts
+  -h, --help               help for artifacts
+  -o, --output string      output mode (JSON, json, tree, wide, yaml)
+  -r, --recursive          follow index nesting
+      --repo string        repository name or spec
+  -s, --sort stringArray   sort fields
 ```
 
 ### Description
 
 
-Describe lists all artefact versions specified, if only a repository is specified
-all tagged artefacts are listed.
-Per version a detailed, potentially recursive description is printed.
-
-
+Get lists all artifact versions specified, if only a repository is specified
+all tagged artifacts are listed.
+	
 If the repository/registry option is specified, the given names are interpreted
 relative to the specified registry using the syntax
 
@@ -42,7 +42,7 @@ relative to the specified registry using the syntax
 </center>
 
 If no <code>--repo</code> option is specified the given names are interpreted 
-as extended OCI artefact references.
+as extended OCI artifact references.
 
 <center>
     <pre>[&lt;repo type>::]&lt;host>[:&lt;port>]/&lt;OCI repository name>[:&lt;tag>][@&lt;digest>]</pre>
@@ -59,7 +59,7 @@ For the *Common Transport Format* the types <code>directory</code>,
 
 Using the JSON variant any repository type supported by the 
 linked library can be used:
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -67,10 +67,14 @@ linked library can be used:
 - `oci`
 - `ociRegistry`
 
+With the option <code>--recursive</code> the complete reference tree of a index is traversed.
+
 With the option <code>--output</code> the output mode can be selected.
 The following modes are supported:
  - JSON
  - json
+ - tree
+ - wide
  - yaml
 
 
@@ -78,12 +82,12 @@ The following modes are supported:
 
 ```
 
-$ ocm describe artefact ghcr.io/mandelsoft/kubelink
-$ ocm describe artefact --repo OCIRegistry:ghcr.io mandelsoft/kubelink
+$ ocm get artifact ghcr.io/mandelsoft/kubelink
+$ ocm get artifact --repo OCIRegistry:ghcr.io mandelsoft/kubelink
 
 ```
 
 ### See Also
 
-* [ocm describe](/docs/cli/describe)	 &mdash; Describe artefacts
+* [ocm get](/docs/cli/get)	 &mdash; Get information about artifacts and components
 

--- a/content/en/docs/cli-reference/get/get_componentversions.md
+++ b/content/en/docs/cli-reference/get/get_componentversions.md
@@ -72,7 +72,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -120,5 +120,5 @@ $ ocm get componentversion --repo OCIRegistry:ghcr.io mandelsoft/kubelink
 
 ### See Also
 
-* [ocm get](/docs/cli/get)	 &mdash; Get information about artefacts and components
+* [ocm get](/docs/cli/get)	 &mdash; Get information about artifacts and components
 

--- a/content/en/docs/cli-reference/get/get_credentials.md
+++ b/content/en/docs/cli-reference/get/get_credentials.md
@@ -64,5 +64,5 @@ The usage of a dedicated matcher can be enforced by the option <code>--matcher</
 
 ### See Also
 
-* [ocm get](/docs/cli/get)	 &mdash; Get information about artefacts and components
+* [ocm get](/docs/cli/get)	 &mdash; Get information about artifacts and components
 

--- a/content/en/docs/cli-reference/get/get_references.md
+++ b/content/en/docs/cli-reference/get/get_references.md
@@ -73,7 +73,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -104,5 +104,5 @@ The following modes are supported:
 
 ### See Also
 
-* [ocm get](/docs/cli/get)	 &mdash; Get information about artefacts and components
+* [ocm get](/docs/cli/get)	 &mdash; Get information about artifacts and components
 

--- a/content/en/docs/cli-reference/get/get_resources.md
+++ b/content/en/docs/cli-reference/get/get_resources.md
@@ -73,7 +73,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -105,5 +105,5 @@ The following modes are supported:
 
 ### See Also
 
-* [ocm get](/docs/cli/get)	 &mdash; Get information about artefacts and components
+* [ocm get](/docs/cli/get)	 &mdash; Get information about artifacts and components
 

--- a/content/en/docs/cli-reference/get/get_sources.md
+++ b/content/en/docs/cli-reference/get/get_sources.md
@@ -73,7 +73,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -104,5 +104,5 @@ The following modes are supported:
 
 ### See Also
 
-* [ocm get](/docs/cli/get)	 &mdash; Get information about artefacts and components
+* [ocm get](/docs/cli/get)	 &mdash; Get information about artifacts and components
 

--- a/content/en/docs/cli-reference/show/_index.md
+++ b/content/en/docs/cli-reference/show/_index.md
@@ -29,6 +29,6 @@ ocm show [<options>] <sub command> ...
 
 ##### Sub Commands
 
-* [ocm show <b>tags</b>](/docs/cli/show/tags)	 &mdash; show dedicated tags of OCI artefacts
+* [ocm show <b>tags</b>](/docs/cli/show/tags)	 &mdash; show dedicated tags of OCI artifacts
 * [ocm show <b>versions</b>](/docs/cli/show/versions)	 &mdash; show dedicated versions (semver compliant)
 

--- a/content/en/docs/cli-reference/show/show_tags.md
+++ b/content/en/docs/cli-reference/show/show_tags.md
@@ -30,7 +30,7 @@ ocm show tags [<options>] <component> {<version pattern>}
 ### Description
 
 
-Match tags of an artefact against some patterns.
+Match tags of an artifact against some patterns.
 
 If the repository/registry option is specified, the given names are interpreted
 relative to the specified registry using the syntax
@@ -40,7 +40,7 @@ relative to the specified registry using the syntax
 </center>
 
 If no <code>--repo</code> option is specified the given names are interpreted 
-as extended OCI artefact references.
+as extended OCI artifact references.
 
 <center>
     <pre>[&lt;repo type>::]&lt;host>[:&lt;port>]/&lt;OCI repository name>[:&lt;tag>][@&lt;digest>]</pre>
@@ -57,7 +57,7 @@ For the *Common Transport Format* the types <code>directory</code>,
 
 Using the JSON variant any repository type supported by the 
 linked library can be used:
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`

--- a/content/en/docs/cli-reference/show/show_versions.md
+++ b/content/en/docs/cli-reference/show/show_versions.md
@@ -68,7 +68,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`

--- a/content/en/docs/cli-reference/sign/sign_componentversions.md
+++ b/content/en/docs/cli-reference/sign/sign_componentversions.md
@@ -78,7 +78,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`

--- a/content/en/docs/cli-reference/transfer/_index.md
+++ b/content/en/docs/cli-reference/transfer/_index.md
@@ -29,7 +29,7 @@ ocm transfer [<options>] <sub command> ...
 
 ##### Sub Commands
 
-* [ocm transfer <b>artefacts</b>](/docs/cli/transfer/artefacts)	 &mdash; transfer OCI artefacts
+* [ocm transfer <b>artifacts</b>](/docs/cli/transfer/artifacts)	 &mdash; transfer OCI artifacts
 * [ocm transfer <b>commontransportarchive</b>](/docs/cli/transfer/commontransportarchive)	 &mdash; transfer transport archive
 * [ocm transfer <b>componentarchive</b>](/docs/cli/transfer/componentarchive)	 &mdash; transfer component archive to some component repository
 * [ocm transfer <b>componentversions</b>](/docs/cli/transfer/componentversions)	 &mdash; transfer component version

--- a/content/en/docs/cli-reference/transfer/transfer_artifacts.md
+++ b/content/en/docs/cli-reference/transfer/transfer_artifacts.md
@@ -1,7 +1,7 @@
 ---
-title: artefacts
-name: transfer artefacts
-url: /docs/cli/transfer/artefacts/
+title: artifacts
+name: transfer artifacts
+url: /docs/cli/transfer/artifacts/
 date: 2022-10-19T11:39:28+01:00
 draft: false
 images: []
@@ -14,13 +14,13 @@ isCommand: true
 ### Usage
 
 ```
-ocm transfer artefacts [<options>] {<artefact-reference>} <target>
+ocm transfer artifacts [<options>] {<artifact-reference>} <target>
 ```
 
 ### Options
 
 ```
-  -h, --help          help for artefacts
+  -h, --help          help for artifacts
       --repo string   repository name or spec
   -R, --repo-name     transfer repository name
 ```
@@ -28,20 +28,20 @@ ocm transfer artefacts [<options>] {<artefact-reference>} <target>
 ### Description
 
 
-Transfer OCI artefacts from one registry to another one.
+Transfer OCI artifacts from one registry to another one.
 Several transfer scenarios are supported:
-- copy a set of artefacts (for the same repository) into another registry
-- copy a set of artefacts (for the same repository) into another repository
-- copy artefacts from multiple repositories into another registry
-- copy artefacts from multiple repositories into another registry with a given repository prefix (option -R)
+- copy a set of artifacts (for the same repository) into another registry
+- copy a set of artifacts (for the same repository) into another repository
+- copy artifacts from multiple repositories into another registry
+- copy artifacts from multiple repositories into another registry with a given repository prefix (option -R)
 
 By default the target is seen as a single repository if a repository is specified.
 If a complete registry is specified as target, option -R is implied, but the source
-must provide a repository. THis combination does not allow an artefact set as source, which
-specifies no repository for the artefacts.
+must provide a repository. THis combination does not allow an artifact set as source, which
+specifies no repository for the artifacts.
 
 Sources may be specified as
-- dedicated artefacts with repository and version or tag
+- dedicated artifacts with repository and version or tag
 - repository (without version), which is resolved to all available tags
 - registry, if the specified registry implementation supports a namespace/repository lister,
   which is not the case for registries conforming to the OCI distribution specification.
@@ -53,7 +53,7 @@ relative to the specified registry using the syntax
 </center>
 
 If no <code>--repo</code> option is specified the given names are interpreted 
-as extended OCI artefact references.
+as extended OCI artifact references.
 
 <center>
     <pre>[&lt;repo type>::]&lt;host>[:&lt;port>]/&lt;OCI repository name>[:&lt;tag>][@&lt;digest>]</pre>
@@ -70,7 +70,7 @@ For the *Common Transport Format* the types <code>directory</code>,
 
 Using the JSON variant any repository type supported by the 
 linked library can be used:
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -83,14 +83,14 @@ linked library can be used:
 
 ```
 
-$ ocm transfer artefact ghcr.io/mandelsoft/kubelink:v1.0.0 gcr.io
-$ ocm transfer artefact ghcr.io/mandelsoft/kubelink gcr.io
-$ ocm transfer artefact ghcr.io/mandelsoft/kubelink gcr.io/my-project
-$ ocm transfer artefact /tmp/ctf gcr.io/my-project
+$ ocm transfer artifact ghcr.io/mandelsoft/kubelink:v1.0.0 gcr.io
+$ ocm transfer artifact ghcr.io/mandelsoft/kubelink gcr.io
+$ ocm transfer artifact ghcr.io/mandelsoft/kubelink gcr.io/my-project
+$ ocm transfer artifact /tmp/ctf gcr.io/my-project
 
 ```
 
 ### See Also
 
-* [ocm transfer](/docs/cli/transfer)	 &mdash; Transfer artefacts or components
+* [ocm transfer](/docs/cli/transfer)	 &mdash; Transfer artifacts or components
 

--- a/content/en/docs/cli-reference/transfer/transfer_commontransportarchive.md
+++ b/content/en/docs/cli-reference/transfer/transfer_commontransportarchive.md
@@ -79,5 +79,5 @@ $ ocm transfer ctf ctf.tgz ghcr.io/mandelsoft/components
 
 ### See Also
 
-* [ocm transfer](/docs/cli/transfer)	 &mdash; Transfer artefacts or components
+* [ocm transfer](/docs/cli/transfer)	 &mdash; Transfer artifacts or components
 

--- a/content/en/docs/cli-reference/transfer/transfer_componentarchive.md
+++ b/content/en/docs/cli-reference/transfer/transfer_componentarchive.md
@@ -45,5 +45,5 @@ The default format is <code>directory</code>.
 
 ### See Also
 
-* [ocm transfer](/docs/cli/transfer)	 &mdash; Transfer artefacts or components
+* [ocm transfer](/docs/cli/transfer)	 &mdash; Transfer artifacts or components
 

--- a/content/en/docs/cli-reference/transfer/transfer_componentversions.md
+++ b/content/en/docs/cli-reference/transfer/transfer_componentversions.md
@@ -75,7 +75,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`
@@ -142,5 +142,5 @@ $ ocm transfer components -t tgz --repo OCIRegistry:ghcr.io mandelsoft/kubelink 
 
 ### See Also
 
-* [ocm transfer](/docs/cli/transfer)	 &mdash; Transfer artefacts or components
+* [ocm transfer](/docs/cli/transfer)	 &mdash; Transfer artifacts or components
 

--- a/content/en/docs/cli-reference/verify/verify_componentversions.md
+++ b/content/en/docs/cli-reference/verify/verify_componentversions.md
@@ -72,7 +72,7 @@ Dedicated OCM repository types:
 - `ComponentArchive`
 
 OCI Repository types (using standard component repository to OCI mapping):
-- `ArtefactSet`
+- `ArtifactSet`
 - `CommonTransportFormat`
 - `DockerDaemon`
 - `Empty`

--- a/content/en/docs/context.md
+++ b/content/en/docs/context.md
@@ -20,10 +20,10 @@ These concepts, processes and tools are often still in use today, even though ev
 ## Why is that a problem?
 A fragmented set of individual, sometimes homegrown, tools used across software components is constantly affecting the ability to deliver software securely, consistently and compliant to cloud, on-premise or hybrid environments.
 
-Individual, overly complex and thus hard-to-operate CI/CD pipelines, and the inability to provide one aggregated "compliance-dashboard" of all currently running artefacts across all environments, result in a tedious, error-prone and ineffective lifecycle-management of software at scale.
+Individual, overly complex and thus hard-to-operate CI/CD pipelines, and the inability to provide one aggregated "compliance-dashboard" of all currently running artifacts across all environments, result in a tedious, error-prone and ineffective lifecycle-management of software at scale.
 
 ## How can this improve?
-The major problem here is the absence of **a standardized software component model used to describe all software components, including their technical artefacts**. 
+The major problem here is the absence of **a standardized software component model used to describe all software components, including their technical artifacts**. 
 
 Such a model would not only help to streamline **deployments to various environments** (public, private, hybrid), but also in other areas of lifecycle-management like **compliance and reporting**.
 
@@ -33,31 +33,31 @@ Let's have a look at the most crucial features a standardized software component
 ### Immutable Component-ID
 An immutable Component-ID must be established by the model for each software component. This ID could be used by all subsequent lifecycle-management processes like compliance scanning. One might think of this as a "correlation ID", which makes it possible to correlate the various lifecycle-management tools and processes (including their results) to one single identifiable software component.
 
-### Artefact Descriptions with Location Information
-The model must support the description of all artefacts required for a specific software component to be deployed. This list of technical artefacts (or "resources") can be defined as **a "Software-Bill-of-Delivery" (SBoD)**, as it is only required to describe those artefacts, which have to be delivered for a successfull deployment.
-These descriptions must also include the concrete technical access locations, from where each artefact can be retrieved from. 
+### Artifact Descriptions with Location Information
+The model must support the description of all artifacts required for a specific software component to be deployed. This list of technical artifacts (or "resources") can be defined as **a "Software-Bill-of-Delivery" (SBoD)**, as it is only required to describe those artifacts, which have to be delivered for a successfull deployment.
+These descriptions must also include the concrete technical access locations, from where each artifact can be retrieved from. 
 
-### Separation of Component-ID and Artefact Location
-Some of the aforementioned environments prescribe the use of artefacts stored in local registries, **requiring the process of copying technical artefacts into such target environments**. This is especially true for private or air-gapped use-cases, where it is usually not possible to pull artefacts from their original location (due to restricted/non-existing internet access or for compliance reasons). These scenarios require that **software components must separate their immutable ID from the current location of their technical artefacts**: The Component-ID needs to stay stable, across all environments and landscapes, whereas the artefact locations have to be changeable.
+### Separation of Component-ID and Artifact Location
+Some of the aforementioned environments prescribe the use of artifacts stored in local registries, **requiring the process of copying technical artifacts into such target environments**. This is especially true for private or air-gapped use-cases, where it is usually not possible to pull artifacts from their original location (due to restricted/non-existing internet access or for compliance reasons). These scenarios require that **software components must separate their immutable ID from the current location of their technical artifacts**: The Component-ID needs to stay stable, across all environments and landscapes, whereas the artifact locations have to be changeable.
 
 ### Technology-Agnostic
 At its heart, the model needs to be **technology-agnostic**, so that not only modern containerized cloud, but also legacy software is supported. Larger companies usually operate some kind of hybrid landscapes these days, where parts are modern cloud native software applications running on cloud infrastructures, and other parts are legacy apps, which have not yet (or will never be) transitioned to the cloud or put into containers.<br>
-This fact makes it crucial to **establish a software component model, which is able to handle both cloud native and legacy software**, so it needs to be fully agnostic about the technologies used by the described software components and their artefacts.
+This fact makes it crucial to **establish a software component model, which is able to handle both cloud native and legacy software**, so it needs to be fully agnostic about the technologies used by the described software components and their artifacts.
 
 ### Extensibility
 Additionally, the **model needs to be extensible**. Being able to easily adapt to future trends and technologies, without constantly affecting the tools and processes used for lifecycle-managing the software, is a must.
 
 ### Signing 
-The model needs to support signing and verification processes out-of-the-box. This enables consumers of software components to verify that delivered components have not been tampered with. The signing and verification support has to acknowledge the fact that the technical artefact locations may change over time, which means that these concrete locations must not be part of the signing process.
+The model needs to support signing and verification processes out-of-the-box. This enables consumers of software components to verify that delivered components have not been tampered with. The signing and verification support has to acknowledge the fact that the technical artifact locations may change over time, which means that these concrete locations must not be part of the signing process.
 
 ## TL;DR - Summary
 All of the above boils down to the following requirements.<br>
 A modern standardized software component model must:
-- describe all individual technical artefacts of a software component 
-- provide access information for these artefacts 
+- describe all individual technical artifacts of a software component 
+- provide access information for these artifacts 
 - establish an immutable Component-ID, to be used across all lifecycle-management processes
-- establish a clear separation of the immutable ID from the technical artefact locations
-- handle technical artefacts in a technology-agnostic way
+- establish a clear separation of the immutable ID from the technical artifact locations
+- handle technical artifacts in a technology-agnostic way
 - be extensible to support future use-cases
 - support standard signing and verification processes
 

--- a/content/en/project/about.md
+++ b/content/en/project/about.md
@@ -11,7 +11,7 @@ menu:
         parent: ""
 ---
 
-The Open Component Model provides a standard for describing delivery artefacts that can be accessed from many types of component repositories.
+The Open Component Model provides a standard for describing delivery artifacts that can be accessed from many types of component repositories.
 
 The following projects form this set of solutions (and more are in the works):
 - [OCM Specifications](https://github.com/open-component-model/ocm-spec/tree/main/doc/specification) - The `ocm-spec` repository contains semantic, formatting, and other types of specifications for OCM.


### PR DESCRIPTION
```bash
rg -l artefact | xargs -I {} sed -i 's/artefact/artifact/g' {}
rg -l Artefact | xargs -I {} sed -i 's/Artefact/Artifact/g' {}

find . -name '*artefact*' | grep -v '.git' | xargs -I {} rename artefact artifact {}
```

Related to: https://github.com/open-component-model/ocm/issues/183