### PR TITLE
Add json schema to website

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -30,3 +30,4 @@
 #   name = "Privacy"
 #   url = "/privacy-policy/"
 #   weight = 10
+

--- a/content/en/spec/_index.md
+++ b/content/en/spec/_index.md
@@ -6,6 +6,6 @@ date: 2022-09-15 20:55:05.533505515 +0100 IST m=+0.000179772
 draft: false
 ---
 
-| Version  | Description                              |
-| -------- | ---------------------------------------- |
-| [v0.0.0 (Latest)]( https://github.com/open-component-model/ocm-spec ) | The most up-to-date version of the OCM specification |
+| Version  | Description                              | Schema |
+| -------- | ---------------------------------------- | -------|
+| [v0.0.0 (Latest)]( https://github.com/open-component-model/ocm-spec ) | The most up-to-date version of the OCM specification | [v2](/schemas/component-descriptor-v2) \| [v3alpha1](/schemas/component-descriptor-v3alpha1)

--- a/static/schemas/component-descriptor-v2
+++ b/static/schemas/component-descriptor-v2
@@ -1,0 +1,671 @@
+{
+  "$id": "https://gardener.cloud/schemas/component-descriptor-v2",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Gardener Component Descriptor v2 schema",
+  "definitions": {
+    "meta": {
+      "type": "object",
+      "description": "component descriptor metadata",
+      "required": [
+        "schemaVersion"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "type": "string"
+        }
+      }
+    },
+    "label": {
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {},
+        "version": {
+          "pattern": "^v[0-9]+$"
+        },
+        "signature": {
+          "type": "boolean"
+        }
+      }
+    },
+    "componentName": {
+      "type": "string",
+      "maxLength": 255,
+      "pattern": "^[a-z][-a-z0-9]*([.][a-z][-a-z0-9]*)*[.][a-z]{2,}(/[a-z][-a-z0-9_]*([.][a-z][-a-z0-9_]*)*)+$"
+    },
+    "identityAttributeKey": {
+      "minLength": 2,
+      "pattern": "^[a-z0-9]([-_+a-z0-9]*[a-z0-9])?$"
+    },
+    "relaxedSemver": {
+      "pattern": "^[v]?(0|[1-9]\\d*)(?:\\.(0|[1-9]\\d*))?(?:\\.(0|[1-9]\\d*))?(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "type": "string"
+    },
+    "identityAttribute": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/definitions/identityAttributeKey"
+      }
+    },
+    "repositoryContext": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "ociRepositoryContext": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/repositoryContext"
+        },
+        {
+          "required": [
+            "baseUrl"
+          ],
+          "properties": {
+            "baseUrl": {
+              "type": "string"
+            },
+            "componentNameMapping": {
+              "type": "string",
+              "enum": [
+                "urlPath",
+                "sha256-digest"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "ociRegistry",
+                "OCIRegistry"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "access": {
+      "type": "object",
+      "description": "base type for accesses (for extensions)",
+      "required": [
+        "type"
+      ]
+    },
+    "githubAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "repoUrl",
+        "ref"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "github"
+          ]
+        },
+        "repoUrl": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "commit": {
+          "type": "string"
+        }
+      }
+    },
+    "noneAccess": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "None"
+          ]
+        }
+      }
+    },
+    "sourceDefinition": {
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "type",
+        "access"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "$ref": "#/definitions/identityAttributeKey"
+        },
+        "extraIdentity": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "type": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/label"
+          }
+        },
+        "access": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/access"
+            },
+            {
+              "$ref": "#/definitions/githubAccess"
+            },
+            {
+              "$ref": "#/definitions/httpAccess"
+            }
+          ]
+        }
+      }
+    },
+    "digestSpec": {
+      "type": "object",
+      "required": [
+        "hashAlgorithm",
+        "normalisationAlgorithm",
+        "value"
+      ],
+      "properties": {
+        "hashAlgorithm": {
+          "type": "string"
+        },
+        "normalisationAlgorithm": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "signatureSpec": {
+      "type": "object",
+      "required": [
+        "algorithm",
+        "value",
+        "mediaType"
+      ],
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "mediaType": {
+          "description": "The media type of the signature value",
+          "type": "string"
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "required": [
+        "name",
+        "digest",
+        "signature"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "digest": {
+          "$ref": "#/definitions/digestSpec"
+        },
+        "signature": {
+          "$ref": "#/definitions/signatureSpec"
+        }
+      }
+    },
+    "srcRef": {
+      "type": "object",
+      "description": "a reference to a (component-local) source",
+      "properties": {
+        "identitySelector": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/label"
+          }
+        }
+      }
+    },
+    "componentReference": {
+      "type": "object",
+      "description": "a reference to a component",
+      "required": [
+        "name",
+        "componentName",
+        "version"
+      ],
+      "properties": {
+        "componentName": {
+          "$ref": "#/definitions/componentName"
+        },
+        "name": {
+          "type": "string",
+          "$ref": "#/definitions/identityAttributeKey"
+        },
+        "extraIdentity": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/label"
+          }
+        },
+        "digest": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/digestSpec"
+            }
+          ]
+        }
+      }
+    },
+    "resourceType": {
+      "type": "object",
+      "description": "base type for resources",
+      "required": [
+        "name",
+        "version",
+        "type",
+        "relation",
+        "access"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "$ref": "#/definitions/identityAttributeKey"
+        },
+        "extraIdentity": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "type": {
+          "type": "string"
+        },
+        "srcRefs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/srcRef"
+          }
+        },
+        "relation": {
+          "type": "string",
+          "enum": [
+            "local",
+            "external"
+          ]
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/label"
+          }
+        },
+        "access": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/access"
+            },
+            {
+              "$ref": "#/definitions/ociBlobAccess"
+            },
+            {
+              "$ref": "#/definitions/localFilesystemBlobAccess"
+            },
+            {
+              "$ref": "#/definitions/localOciBlobAccess"
+            }
+          ]
+        },
+        "digest": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/digestSpec"
+            }
+          ]
+        }
+      }
+    },
+    "ociImageAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "imageReference"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ociRegistry"
+          ]
+        },
+        "imageReference": {
+          "type": "string"
+        }
+      }
+    },
+    "ociBlobAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "layer"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ociBlob"
+          ]
+        },
+        "ref": {
+          "description": "A oci reference to the manifest",
+          "type": "string"
+        },
+        "mediaType": {
+          "description": "The media type of the object this access refers to",
+          "type": "string"
+        },
+        "digest": {
+          "description": "The digest of the targeted content",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size in bytes of the blob",
+          "type": "number"
+        }
+      }
+    },
+    "localFilesystemBlobAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "filename"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "localFilesystemBlob"
+          ]
+        },
+        "filename": {
+          "description": "filename of the blob that is located in the \"blobs\" directory",
+          "type": "string"
+        }
+      }
+    },
+    "localOciBlobAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "filename"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "localOciBlob"
+          ]
+        },
+        "digest": {
+          "description": "digest of the layer within the current component descriptor",
+          "type": "string"
+        }
+      }
+    },
+    "ociImageResource": {
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "type",
+        "access"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "$ref": "#/definitions/identityAttributeKey"
+        },
+        "extraIdentity": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "ociImage"
+          ]
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/label"
+          }
+        },
+        "access": {
+          "$ref": "#/definitions/ociImageAccess"
+        },
+        "digest": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/digestSpec"
+            }
+          ]
+        }
+      }
+    },
+    "httpAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "url"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "genericAccess": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "generic"
+          ]
+        }
+      }
+    },
+    "genericResource": {
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "type",
+        "access"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "$ref": "#/definitions/identityAttributeKey"
+        },
+        "extraIdentity": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "generic"
+          ]
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/label"
+          }
+        },
+        "access": {
+          "$ref": "#/definitions/genericAccess"
+        },
+        "digest": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/digestSpec"
+            }
+          ]
+        }
+      }
+    },
+    "component": {
+      "type": "object",
+      "description": "a component",
+      "required": [
+        "name",
+        "version",
+        "repositoryContexts",
+        "provider",
+        "sources",
+        "componentReferences",
+        "resources"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/componentName"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "repositoryContexts": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ociRepositoryContext"
+              }
+            ]
+          }
+        },
+        "provider": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/label"
+          }
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/sourceDefinition"
+          }
+        },
+        "componentReferences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/componentReference"
+          }
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/resourceType"
+              },
+              {
+                "$ref": "#/definitions/ociImageResource"
+              },
+              {
+                "$ref": "#/definitions/genericResource"
+              }
+            ]
+          }
+        }
+      },
+      "componentReferences": {}
+    }
+  },
+  "type": "object",
+  "required": [
+    "meta",
+    "component"
+  ],
+  "properties": {
+    "meta": {
+      "$ref": "#/definitions/meta"
+    },
+    "component": {
+      "$ref": "#/definitions/component"
+    },
+    "signatures": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/signature"
+      }
+    }
+  }
+}

--- a/static/schemas/component-descriptor-v3alpha1
+++ b/static/schemas/component-descriptor-v3alpha1
@@ -1,0 +1,680 @@
+{
+  "$id": "https://gardener.cloud/schemas/component-descriptor-ocm-v3alpha1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "OCM Component Descriptor v3 schema",
+  "definitions": {
+    "meta": {
+      "type": "object",
+      "description": "component version metadata",
+      "required": [
+        "name",
+        "version"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/componentName"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "labels": {
+          "$ref": "#/definitions/labels"
+        },
+        "provider": {
+          "$ref": "#/definitions/provider"
+        }
+      }
+    },
+    "labels": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/label"
+      }
+    },
+    "label": {
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {},
+        "version": {
+          "pattern": "^v[0-9]+$"
+        },
+        "signature": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "componentName": {
+      "type": "string",
+      "maxLength": 255,
+      "pattern": "^[a-z][-a-z0-9]*([.][a-z][-a-z0-9]*)*[.][a-z]{2,}(/[a-z][-a-z0-9_]*([.][a-z][-a-z0-9_]*)*)+$"
+    },
+    "identityAttributeKey": {
+      "minLength": 2,
+      "pattern": "^[a-z0-9]([-_+a-z0-9]*[a-z0-9])?$"
+    },
+    "relaxedSemver": {
+      "pattern": "^[v]?(0|[1-9]\\d*)(?:\\.(0|[1-9]\\d*))?(?:\\.(0|[1-9]\\d*))?(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "type": "string"
+    },
+    "identityAttribute": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/definitions/identityAttributeKey"
+      }
+    },
+    "repositoryContext": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "ociRepositoryContext": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/repositoryContext"
+        },
+        {
+          "required": [
+            "baseUrl"
+          ],
+          "properties": {
+            "baseUrl": {
+              "type": "string"
+            },
+            "componentNameMapping": {
+              "type": "string",
+              "enum": [
+                "urlPath",
+                "sha256-digest"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "ociRegistry",
+                "OCIRegistry"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "access": {
+      "type": "object",
+      "description": "base type for accesses (for extensions)",
+      "required": [
+        "type"
+      ]
+    },
+    "githubAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "repoUrl",
+        "ref"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "github"
+          ]
+        },
+        "repoUrl": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "commit": {
+          "type": "string"
+        }
+      }
+    },
+    "noneAccess": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "None"
+          ]
+        }
+      }
+    },
+    "sourceDefinition": {
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "type",
+        "access"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "$ref": "#/definitions/identityAttributeKey"
+        },
+        "extraIdentity": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "type": {
+          "type": "string"
+        },
+        "labels": {
+          "$ref": "#/definitions/labels"
+        },
+        "access": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/access"
+            },
+            {
+              "$ref": "#/definitions/githubAccess"
+            },
+            {
+              "$ref": "#/definitions/httpAccess"
+            }
+          ]
+        }
+      }
+    },
+    "digestSpec": {
+      "type": "object",
+      "required": [
+        "hashAlgorithm",
+        "normalisationAlgorithm",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "hashAlgorithm": {
+          "type": "string"
+        },
+        "normalisationAlgorithm": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "signatureSpec": {
+      "type": "object",
+      "required": [
+        "algorithm",
+        "value",
+        "mediaType"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "mediaType": {
+          "description": "The media type of the signature value",
+          "type": "string"
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "required": [
+        "name",
+        "digest",
+        "signature"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "digest": {
+          "$ref": "#/definitions/digestSpec"
+        },
+        "signature": {
+          "$ref": "#/definitions/signatureSpec"
+        }
+      }
+    },
+    "srcRef": {
+      "type": "object",
+      "description": "a reference to a (component-local) source",
+      "properties": {
+        "identitySelector": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "labels": {
+          "$ref": "#/definitions/labels"
+        }
+      }
+    },
+    "reference": {
+      "type": "object",
+      "description": "a reference to a component",
+      "required": [
+        "name",
+        "componentName",
+        "version"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "componentName": {
+          "$ref": "#/definitions/componentName"
+        },
+        "name": {
+          "type": "string",
+          "$ref": "#/definitions/identityAttributeKey"
+        },
+        "extraIdentity": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "labels": {
+          "$ref": "#/definitions/labels"
+        },
+        "digest": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/digestSpec"
+            }
+          ]
+        }
+      }
+    },
+    "resourceType": {
+      "type": "object",
+      "description": "base type for resources",
+      "required": [
+        "name",
+        "version",
+        "type",
+        "relation",
+        "access"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "$ref": "#/definitions/identityAttributeKey"
+        },
+        "extraIdentity": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "type": {
+          "type": "string"
+        },
+        "srcRefs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/srcRef"
+          }
+        },
+        "relation": {
+          "type": "string",
+          "enum": [
+            "local",
+            "external"
+          ]
+        },
+        "labels": {
+          "$ref": "#/definitions/labels"
+        },
+        "access": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/access"
+            },
+            {
+              "$ref": "#/definitions/ociBlobAccess"
+            },
+            {
+              "$ref": "#/definitions/localFilesystemBlobAccess"
+            },
+            {
+              "$ref": "#/definitions/localOciBlobAccess"
+            }
+          ]
+        },
+        "digest": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/digestSpec"
+            }
+          ]
+        }
+      }
+    },
+    "ociImageAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "imageReference"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ociRegistry"
+          ]
+        },
+        "imageReference": {
+          "type": "string"
+        }
+      }
+    },
+    "ociBlobAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "layer"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ociBlob"
+          ]
+        },
+        "ref": {
+          "description": "A oci reference to the manifest",
+          "type": "string"
+        },
+        "mediaType": {
+          "description": "The media type of the object this access refers to",
+          "type": "string"
+        },
+        "digest": {
+          "description": "The digest of the targeted content",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size in bytes of the blob",
+          "type": "number"
+        }
+      }
+    },
+    "localFilesystemBlobAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "filename"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "localFilesystemBlob"
+          ]
+        },
+        "filename": {
+          "description": "filename of the blob that is located in the \"blobs\" directory",
+          "type": "string"
+        }
+      }
+    },
+    "localOciBlobAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "filename"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "localOciBlob"
+          ]
+        },
+        "digest": {
+          "description": "digest of the layer within the current component descriptor",
+          "type": "string"
+        }
+      }
+    },
+    "ociImageResource": {
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "type",
+        "access"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "$ref": "#/definitions/identityAttributeKey"
+        },
+        "extraIdentity": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "ociImage"
+          ]
+        },
+        "labels": {
+          "$ref": "#/definitions/labels"
+        },
+        "access": {
+          "$ref": "#/definitions/ociImageAccess"
+        },
+        "digest": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/digestSpec"
+            }
+          ]
+        }
+      }
+    },
+    "httpAccess": {
+      "type": "object",
+      "required": [
+        "type",
+        "url"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "genericAccess": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "generic"
+          ]
+        }
+      }
+    },
+    "genericResource": {
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "type",
+        "access"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "$ref": "#/definitions/identityAttributeKey"
+        },
+        "extraIdentity": {
+          "$ref": "#/definitions/identityAttribute"
+        },
+        "version": {
+          "$ref": "#/definitions/relaxedSemver"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "generic"
+          ]
+        },
+        "labels": {
+          "$ref": "#/definitions/labels"
+        },
+        "access": {
+          "$ref": "#/definitions/genericAccess"
+        },
+        "digest": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/digestSpec"
+            }
+          ]
+        }
+      }
+    },
+    "provider": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "labels": {
+          "$ref": "#/definitions/labels"
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "description": "specification of the content of a component versiont",
+      "additionalProperties": false,
+      "properties": {
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/sourceDefinition"
+          }
+        },
+        "references": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/reference"
+          }
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/resourceType"
+              },
+              {
+                "$ref": "#/definitions/ociImageResource"
+              },
+              {
+                "$ref": "#/definitions/genericResource"
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "enum": [
+        "ocm.gardener.cloud/v3alpha1",
+        "ocm.software/v3alpha1"
+      ]
+    },
+    "kind": {
+      "type": "string",
+      "const": "ComponentVersion"
+    },
+    "metadata": {
+      "$ref": "#/definitions/meta"
+    },
+    "repositoryContexts": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/ociRepositoryContext"
+          }
+        ]
+      }
+    },
+    "spec": {
+      "$ref": "#/definitions/spec"
+    },
+    "signatures": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/signature"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Schema should be accessible via the ocm.software domain. Links to schema are also present on the spec page.

**Which issue(s) this PR fixes**:
Fixes #13 