### PR TITLE
Adding Installation-Path-Info

### DIFF
--- a/content/en/docs/installation.md
+++ b/content/en/docs/installation.md
@@ -38,6 +38,8 @@ Enter the repository directory (`cd ocm/`) and install the cli using make:
 make install
 ```
 
+> Please note that the OCM CLI is installed in your `go/bin` directory, so you might need to add this directory to your `PATH`.
+
 Verify the installation:
 
 ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:
Short info added regarding the go/bin path, where the OCM CLI is going to be installed into.

**Which issue(s) this PR fixes**:
Slightly unclear where the installed binary is located after installation.

