### PR TITLE
Ensure `./config` is updated when releasing docs

### DIFF
--- a/.github/workflows/update-cli-docs.yaml
+++ b/.github/workflows/update-cli-docs.yaml
@@ -53,7 +53,9 @@ jobs:
       with:
         title: "Update CLI docs"
         commit-message: "[github-actions] automated change"
-        add-paths: content/
+        add-paths: |
+          config/
+          content/
         branch: update-cli-docs/auto
         branch-suffix: timestamp
         delete-branch: true


### PR DESCRIPTION
## Description

This PR ensures that the latest_version tag is updated when a website updated is triggered.

Signed-off-by: Piaras Hoban <phoban01@gmail.com>

