### PR TITLE
Fix installer script

### DIFF
--- a/static/install.sh
+++ b/static/install.sh
@@ -162,7 +162,7 @@ vercomp () {
 
 # Download hash from Github URL
 download_hash() {
-    HASH_URL="https://github.com/${GITHUB_REPO}/releases/download/v${VERSION_OCM}/ocm-${VERSION_OCM}-checksums.txt"
+    HASH_URL="https://github.com/${GITHUB_REPO}/releases/download/v${VERSION_OCM}/ocm_${VERSION_OCM}_checksums.txt"
     info "Downloading hash ${HASH_URL}"
     download "${TMP_HASH}" "${HASH_URL}"
     info "ocm-${OS}-${ARCH}.tar.gz"


### PR DESCRIPTION
**What this PR does / why we need it**:

The HASH_URL used to validate checksums was incorrect.

Signed-off-by: Piaras Hoban <phoban01@gmail.com>
