### PR TITLE
Fix 'Get Started' button link

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,8 @@
         <p class="text-white leader-open-source-text">{{.Site.Params.leader_open_source_text}} <a href="https://github.com/open-component-model/ocm/releases/tag/{{ .Site.Params.latest_version }}">GitHub {{ .Site.Params.latest_version }}</a></p>
         <div class="homepage-cta">
           <span class="btn-bg"></span>
-          <a href="/docs/guides/getting-started-with-ocm-flux"><button class="btn-cta">Get Started</button></a>
+
+          <a href="/docs/guides/deploying-applications-with-ocm-and-gitops"><button class="btn-cta">Get Started</button></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

Ensure the button link on the homepage points to the new guides.

Signed-off-by: Piaras Hoban <phoban01@gmail.com>

