### PR TITLE
fix missing OCM_REPO var in getting started guide

### DIFF
--- a/content/en/docs/guides/getting-started-with-ocm.md
+++ b/content/en/docs/guides/getting-started-with-ocm.md
@@ -83,9 +83,14 @@ ORG="acme"
 COMPONENT="github.com/${ORG}/helloworld"
 VERSION="1.0.0"
 CA_ARCHIVE="ca-hello-world"
+OCM_REPO="ghcr.io/<github-org>/ocm"
 ```
 
 If you specify values for your setup, you can directly use the commands shown in the next steps.
+The variable `OCM_REPO` is set to a location of an OCI registry where artifacts and component
+descriptors are stored (omitting the `https://` prefix). For example
+[GitHub Packages](https://github.com/features/packages) can be used as an OCI registry. Many other
+options exist.
 
 Let's asssume that we create a component based on a GitHub source repository.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The variable OCM_REPO was not mentioned in getting started guide. This results in errors for people following the tutorial.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
