### PR TITLE
Adjust Get Started Landing Page Link

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
         </p>
         <div class="homepage-cta">
           <span class="btn-bg"></span>
-          <a href="/docs/guides/deploying-applications-with-ocm-and-gitops"><button class="btn-cta">Get Started</button></a>
+          <a href="/docs/guides/getting-started-with-ocm"><button class="btn-cta">Get Started</button></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description
The 'Get Started' Link on the Landing Page points to a Guide about ocm and gitops. In my opinion, this should much rather link to the Getting Started with OCM Guide. 
