### PR TITLE
(fix) missing apiVersion in ocm-hello-world-podinfo ComponentVersion + (fix) local execution npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npm install
 Then run the site:
 
 ```bash
-npm run start
+npm run dev
 ```
 
 Navigate to `http://localhost:1313` to see the site running in your browser. Any updates you make to the site will be reflected in the browser immediately.

--- a/content/docs/tutorials/build-deploy-software-via-helm-charts-with-ocm-101.md
+++ b/content/docs/tutorials/build-deploy-software-via-helm-charts-with-ocm-101.md
@@ -442,6 +442,7 @@ Create file [`k8s-component-version/01-pod-info-kind.yaml`](https://github.com/o
 
 ```yaml
 #k8s-component-version/01-pod-info-kind.yaml
+apiVersion: delivery.ocm.software/v1alpha1
 kind: ComponentVersion
 metadata:
   name: ocm-hello-world-podinfo


### PR DESCRIPTION
## Description

This PR fixes a missing `apiVersion` in one of the YAML [descriptors](https://ocm.software/docs/tutorials/build-deploy-infrastructure-via-helm-charts-with-ocm/#apply-k8s-manifest) and updates the local execution guide.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
-

## Screenshots


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
