### PR TITLE
Added clarification on multi-arch images

### DIFF
--- a/content/docs/cli-reference/add/add_resources.md
+++ b/content/docs/cli-reference/add/add_resources.md
@@ -235,7 +235,7 @@ with the field <code>type</code> in the <code>input</code> field:
 
 - Input type <code>docker</code>
 
-  The path must denote an image tag that can be found in the local
+  The path must denote an image tag (can reference a multi-arch image) that can be found in the local
   docker daemon. The denoted image is packed as OCI artifact set.
   The OCI image will contain an informational back link to the component version
   using the manifest annotation <code>software.ocm/component-version</code>.
@@ -258,7 +258,8 @@ with the field <code>type</code> in the <code>input</code> field:
 
   This input type describes the composition of a multi-platform OCI image.
   The various variants are taken from the local docker daemon. They should be 
-  built with the buildx command for cross platform docker builds.
+  [built with the `buildx` command](../../tutorials/best-practices-with-ocm.md#building-multi-arch-images) for cross platform docker builds.
+
   The denoted images, as well as the wrapping image index is packed as OCI
   artifact set.
   They will contain an informational back link to the component version
@@ -906,5 +907,4 @@ $ ocm add resources --file path/to/ca  resources.yaml VERSION=1.0.0
 
 ### See Also
 
-* [ocm add](/docs/cli-reference/add)	 &mdash; Add elements to a component repository or component version
-
+- [ocm add](/docs/cli-reference/add) &mdash; Add elements to a component repository or component version

--- a/content/docs/tutorials/best-practices-with-ocm.md
+++ b/content/docs/tutorials/best-practices-with-ocm.md
@@ -10,7 +10,7 @@ weight: 63
 toc: true
 ---
 
-This chapter contains guidelines for common scenarios how to work with the Open Component Model.
+This chapter contains guidelines for common scenarios how to work with the Open Component Model, focusing on using CI/CD, building, and publishing.
 
 - [Separate between Build and Publish](#separate-between-build-and-publish)
 - [Building multi-arch images](#building-multi-arch-images)
@@ -71,13 +71,15 @@ versions are provided by accepted and well-known processes.
 
 ## Building multi-arch images
 
+> **Note:** This section provides information only on on building multi-arch images. If you are instead interested in referencing a multi-arch image, see the [Referencing multi-arch images](#referencing-multi-arch-images) section.
+
 At the time of writing this guide Docker is not able to build multi-architecture (multi-arch)
 images natively. Instead, the `buildx` plugin is used. However, this implies building and pushing
 images in one step to a remote container registry as the local docker image store does not
 support multi-arch images.
 
 The OCM CLI has some built-in support for dealing with multi-arch images during the
-component version composition ([`ocm add resources`](https://github.com/open-component-model/ocm/blob/main/docs/reference/ocm_add_resources.md).
+component version composition ([`ocm add resources`](https://github.com/open-component-model/ocm/blob/main/docs/reference/ocm_add_resources.md)).
 This allows building all artifacts locally and push them in a separate step to a container registry. This
 is done by building single-arch images in a first step (still using `buildx` for cross-platform
 building). In a second step all images are bundled into a multi-arch image, which is stored as
@@ -420,6 +422,7 @@ For better automation and reuse you may consider templating resource files and m
 
 ## Referencing multi-arch images
 
+> **Note:** This section provides information only on on referencing multi-arch images. If you are instead interested in building a multi-arch image, see the [Building multi-arch images](#building-multi-arch-images) section.
 
 ## Using Makefiles
 

--- a/content/docs/tutorials/best-practices-with-ocm.md
+++ b/content/docs/tutorials/best-practices-with-ocm.md
@@ -10,7 +10,7 @@ weight: 63
 toc: true
 ---
 
-This chapter contains guidelines for common scenarios how to work with the Open Component Model, focusing on using CI/CD, building, and publishing.
+This chapter contains guidelines for common scenarios how to work with the Open Component Model, focusing on using CI/CD, build and publishing processes.
 
 - [Separate between Build and Publish](#separate-between-build-and-publish)
 - [Building multi-arch images](#building-multi-arch-images)
@@ -73,10 +73,10 @@ versions are provided by accepted and well-known processes.
 
 > **Note:** This section provides information only on on building multi-arch images. If you are instead interested in referencing a multi-arch image, see the [Referencing multi-arch images](#referencing-multi-arch-images) section.
 
-At the time of writing this guide Docker is not able to build multi-architecture (multi-arch)
+At the time of writing this guide Docker is not able to build multi-architecture (multi-arch / multi-platform)
 images natively. Instead, the `buildx` plugin is used. However, this implies building and pushing
 images in one step to a remote container registry as the local docker image store does not
-support multi-arch images.
+support multi-arch images (for additional information, see the [Multi-arch build and images, the simple way](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way) blogpost)
 
 The OCM CLI has some built-in support for dealing with multi-arch images during the
 component version composition ([`ocm add resources`](https://github.com/open-component-model/ocm/blob/main/docs/reference/ocm_add_resources.md)).


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR adds clarification on the sections for Building and Referencing a Multi-Arch Image. It also links to the Building a Multi-Arch Image section from the Add Resource topic.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [X] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Closes https://github.com/open-component-model/ocm-project/issues/191



