### PR TITLE
Add dependency reference for ocm library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ resources/_gen/
 ocm-cli/
 ocm-spec/
 public/
+.idea/

--- a/static/ocm
+++ b/static/ocm
@@ -1,0 +1,10 @@
+<html><head>
+  <meta name="go-import"
+        content="ocm.software/ocm
+                 git https://github.com/open-component-model/ocm">
+  <meta name="go-source"
+        content="ocm.software/ocm
+                 https://github.com/open-component-model/ocm
+                 https://github.com/open-component-model/ocm/tree/master{/dir}
+                 https://github.com/mopen-component-model/ocm/blob/master{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
#### What this PR does / why we need it:
We decided to keep the restructured library in the current ocm repository. Therefore, for now, we'd like to be able to import the current library using the ocm url.

