### PR TITLE
fixed reference for external helm chart

### DIFF
--- a/content/docs/tutorials/build-deploy-software-via-helm-charts-with-ocm-101.md
+++ b/content/docs/tutorials/build-deploy-software-via-helm-charts-with-ocm-101.md
@@ -478,7 +478,7 @@ spec:
     name: ocm-hello-world-podinfo
     namespace: ocm-system
     resourceRef:
-      name: helm-chart-external
+      name: helm-chart-external-helm-repo
       version: "6.7.0"
 ---
 apiVersion: delivery.ocm.software/v1alpha1


### PR DESCRIPTION
#### What this PR does / why we need it:
I changed the name of the helm-chart-external reference to use the correct one, as it is defined in the input specification here:
https://github.com/open-component-model/ocm-website/blob/5ad2aa8dccbe4e035f11de6e837b02404376138e/content/docs/tutorials/build-deploy-software-via-helm-charts-with-ocm-101.md?plain=1#L99-L102

#### Which issue(s) this PR fixes:
no issue created for it
