### PR TITLE
fix: do not exit script if vercomp returns non-zero value

### DIFF
--- a/static/install.sh
+++ b/static/install.sh
@@ -163,8 +163,7 @@ vercomp () {
 # Download hash from Github URL
 download_hash() {
     # check for versions < 0.15.0
-    vercomp "$VERSION_OCM" "0.15.0"
-    if [[ $? -eq 2 ]]; then
+    if vercomp "$VERSION_OCM" "0.15.0"; [[ $? -eq 2 ]]; then
         HASH_URL="https://github.com/${GITHUB_REPO}/releases/download/v${VERSION_OCM}/ocm_${VERSION_OCM}_checksums.txt"
         info "Downloading hash ${HASH_URL}"
         download "${TMP_HASH}" "${HASH_URL}"


### PR DESCRIPTION
#### What this PR does / why we need it:
This fixes a bug introduced in commit f1e6c16c613fa13b703bc4c78513d91e79e104dc.

The script uses `set -e`, so it will exit on any function call that returns a non-zero exit code.
Since *download_hash* is calling the vercomp version and vercomp returns 1,2 if the arguments (version1, version2) do not match, the script will exit.



#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
