### PR TITLE
fix: Update `ocm-cli` docs

### DIFF
--- a/.github/workflows/manual-update-cli-docs.yaml
+++ b/.github/workflows/manual-update-cli-docs.yaml
@@ -32,7 +32,7 @@ jobs:
         fi
         # let's check if the version is already published
         curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/open-component-model/ocm/releases > versions.txt
-        grep -Fxq '${{ github.event.inputs.version }}' versions.txt && echo "Version found" || echo "Version not found" && exit 1
+        grep -Fxq '${{ github.event.inputs.version }}' versions.txt && echo "Version (${{ github.event.inputs.version }}) found" || echo "Version (${{ github.event.inputs.version }}) not found!" && exit 1
         echo "RELEASE_VERSION=$(echo ${{ github.event.inputs.version }} )" >> $GITHUB_ENV
     - name: Publish Event
       uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/manual-update-cli-docs.yaml
+++ b/.github/workflows/manual-update-cli-docs.yaml
@@ -14,21 +14,26 @@ jobs:
     name: Create new "Release Publish Event"
     runs-on: ubuntu-latest
     permissions:
-      id-token: 'write'
+      contents: write
+      id-token: write
+      packages: write
     steps:
-    - name: Ensure proper version
-      run: |
-        if ![ -n "${{ github.event.inputs.version }}" ]; then
-          echo "Version not provided"
-          exit 1
-        fi
-        echo "RELEASE_VERSION=$(echo ${{ github.event.inputs.version }} | tr -d ['v'])" >> $GITHUB_ENV
     - name: Generate token
       id: generate_token
       uses: tibdex/github-app-token@v2
       with:
         app_id: ${{ secrets.OCMBOT_APP_ID }}
         private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
+    - name: Ensure proper version
+      run: |
+        if ![ -n "${{ github.event.inputs.version }}" ]; then
+          echo "Version not provided"
+          exit 1
+        fi
+        # let's check if the version is already published
+        curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/open-component-model/ocm/releases > versions.txt
+        grep -Fxq '${{ github.event.inputs.version }}' versions.txt && echo "Version found" || echo "Version not found" && exit 1
+        echo "RELEASE_VERSION=$(echo ${{ github.event.inputs.version }} )" >> $GITHUB_ENV
     - name: Publish Event
       uses: peter-evans/repository-dispatch@v3
       with:

--- a/.github/workflows/manual-update-cli-docs.yaml
+++ b/.github/workflows/manual-update-cli-docs.yaml
@@ -33,7 +33,13 @@ jobs:
         # let's check if the version is already published
         curl -sSL -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/open-component-model/ocm/releases > releases.json
         jq -r '.[] | .tag_name' releases.json | grep -v -E '.*-rc|latest' > versions.txt
-        grep -Fxq '${{ github.event.inputs.version }}' versions.txt && echo "Version (${{ github.event.inputs.version }}) found" || echo "Version (${{ github.event.inputs.version }}) not found!" && cat versions.txt && exit 1
+        if grep -Fxq '${{ github.event.inputs.version }}' versions.txt; then
+          echo "Version (${{ github.event.inputs.version }}) found!"
+        else
+          echo "Version (${{ github.event.inputs.version }}) not found! This are the availble ones:"
+          cat versions.txt
+          exit 1
+        fi
         echo "RELEASE_VERSION=$(echo ${{ github.event.inputs.version }} )" >> $GITHUB_ENV
     - name: Publish Event
       uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/manual-update-cli-docs.yaml
+++ b/.github/workflows/manual-update-cli-docs.yaml
@@ -31,7 +31,8 @@ jobs:
           exit 1
         fi
         # let's check if the version is already published
-        curl -sSL -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/open-component-model/ocm/releases > versions.txt
+        curl -sSL -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/open-component-model/ocm/releases > releases.json
+        jq -r '.[] | .tag_name' releases.json | grep -v -E '.*-rc|latest' > versions.txt
         grep -Fxq '${{ github.event.inputs.version }}' versions.txt && echo "Version (${{ github.event.inputs.version }}) found" || echo "Version (${{ github.event.inputs.version }}) not found!" && cat versions.txt && exit 1
         echo "RELEASE_VERSION=$(echo ${{ github.event.inputs.version }} )" >> $GITHUB_ENV
     - name: Publish Event

--- a/.github/workflows/manual-update-cli-docs.yaml
+++ b/.github/workflows/manual-update-cli-docs.yaml
@@ -45,6 +45,6 @@ jobs:
       uses: peter-evans/repository-dispatch@v3
       with:
         token: ${{ steps.generate_token.outputs.token }}
-        repository: hilmarf/ocm-website
+        repository: ${{ github.repository_owner }}/ocm-website
         event-type: ocm-cli-release
         client-payload: '{"tag": "${{ env.RELEASE_VERSION }}"}'

--- a/.github/workflows/manual-update-cli-docs.yaml
+++ b/.github/workflows/manual-update-cli-docs.yaml
@@ -1,23 +1,20 @@
-name: Manually retrigger the update of the OCM CLI Docs
+name: Manually retrigger the update of the OCM CLI documentation
 
 on:
   workflow_dispatch:
     inputs:
       version:
         type: string
-        description: 'Version of the release (e.g. v0.42.0)'
+        description: Which version (e.g. v0.42.0) do you want to publish?
         required: true
         default: ''
 
 jobs:
   retrigger:
-    name: Update content/docs/cli-reference
-    if: github.event.client_payload != ''
+    name: Create new "Release Publish Event"
     runs-on: ubuntu-latest
     permissions:
-      contents: 'write'
       id-token: 'write'
-      pull-requests: 'write'
     steps:
     - name: Ensure proper version
       run: |

--- a/.github/workflows/manual-update-cli-docs.yaml
+++ b/.github/workflows/manual-update-cli-docs.yaml
@@ -32,7 +32,7 @@ jobs:
         fi
         # let's check if the version is already published
         curl -sSL -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/open-component-model/ocm/releases > versions.txt
-        grep -Fxq '${{ github.event.inputs.version }}' versions.txt && echo "Version (${{ github.event.inputs.version }}) found" || echo "Version (${{ github.event.inputs.version }}) not found!" && exit 1
+        grep -Fxq '${{ github.event.inputs.version }}' versions.txt && echo "Version (${{ github.event.inputs.version }}) found" || echo "Version (${{ github.event.inputs.version }}) not found!" && cat versions.txt && exit 1
         echo "RELEASE_VERSION=$(echo ${{ github.event.inputs.version }} )" >> $GITHUB_ENV
     - name: Publish Event
       uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/manual-update-cli-docs.yaml
+++ b/.github/workflows/manual-update-cli-docs.yaml
@@ -26,12 +26,12 @@ jobs:
         private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
     - name: Ensure proper version
       run: |
-        if ![ -n "${{ github.event.inputs.version }}" ]; then
+        if [ -z "${{ github.event.inputs.version }}" ]; then
           echo "Version not provided"
           exit 1
         fi
         # let's check if the version is already published
-        curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/open-component-model/ocm/releases > versions.txt
+        curl -sSL -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/open-component-model/ocm/releases > versions.txt
         grep -Fxq '${{ github.event.inputs.version }}' versions.txt && echo "Version (${{ github.event.inputs.version }}) found" || echo "Version (${{ github.event.inputs.version }}) not found!" && exit 1
         echo "RELEASE_VERSION=$(echo ${{ github.event.inputs.version }} )" >> $GITHUB_ENV
     - name: Publish Event

--- a/.github/workflows/manual-update-cli-docs.yaml
+++ b/.github/workflows/manual-update-cli-docs.yaml
@@ -1,0 +1,41 @@
+name: Manually retrigger the update of the OCM CLI Docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: 'Version of the release (e.g. v0.42.0)'
+        required: true
+        default: ''
+
+jobs:
+  retrigger:
+    name: Update content/docs/cli-reference
+    if: github.event.client_payload != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'write'
+      id-token: 'write'
+      pull-requests: 'write'
+    steps:
+    - name: Ensure proper version
+      run: |
+        if ![ -n "${{ github.event.inputs.version }}" ]; then
+          echo "Version not provided"
+          exit 1
+        fi
+        echo "RELEASE_VERSION=$(echo ${{ github.event.inputs.version }} | tr -d ['v'])" >> $GITHUB_ENV
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v2
+      with:
+        app_id: ${{ secrets.OCMBOT_APP_ID }}
+        private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
+    - name: Publish Event
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ steps.generate_token.outputs.token }}
+        repository: open-component-model/ocm-website
+        event-type: ocm-cli-release
+        client-payload: '{"tag": "${{ env.RELEASE_VERSION }}"}'

--- a/.github/workflows/manual-update-cli-docs.yaml
+++ b/.github/workflows/manual-update-cli-docs.yaml
@@ -33,6 +33,6 @@ jobs:
       uses: peter-evans/repository-dispatch@v3
       with:
         token: ${{ steps.generate_token.outputs.token }}
-        repository: open-component-model/ocm-website
+        repository: hilmarf/ocm-website
         event-type: ocm-cli-release
         client-payload: '{"tag": "${{ env.RELEASE_VERSION }}"}'

--- a/.github/workflows/update-cli-docs.yaml
+++ b/.github/workflows/update-cli-docs.yaml
@@ -30,7 +30,7 @@ jobs:
         go-version-file: '${{ github.workspace }}/go.mod'
     - name: Regenerate CLI docs
       run: |
-        go get ocm.software/ocm@{{ github.event.client_payload.tag }}
+        go get ocm.software/ocm@${{ github.event.client_payload.tag }}
         go mod tidy
         go run ./hack/generate-cli-docs --output-dir=${{ env.OUTPUT_DIR }}
     - name: Create Pull Request


### PR DESCRIPTION
#### What this PR does / why we need it:

There is one tiny `$` missing! Argh...

And we now have a nice way to retrigger (if necessary) the generation of docs.
