### PR TITLE
chore: dependabot add package-ecosystem: "npm"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,40 @@
 version: 2
 
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    groups:
-      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
-      ci:
-        patterns:
-          - "*"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-    labels:
-      - kind/dependency
-      - kind/chore
-      - kind/skip-release-notes
-      - component/github-actions
-  - package-ecosystem: "gomod"
-    directory: "/"
-    groups:
-      go:
-        update-types:  ["minor","patch"]
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-    labels:
-      - kind/dependency
-      - kind/chore
+- package-ecosystem: "github-actions"
+  directory: "/"
+  groups:
+    # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+    ci:
+      patterns:
+      - "*"
+  schedule:
+    interval: "weekly"
+    day: "sunday"
+  labels:
+  - kind/dependency
+  - kind/chore
+  - kind/skip-release-notes
+  - component/github-actions
+- package-ecosystem: "gomod"
+  directory: "/"
+  groups:
+    go:
+      update-types: [ "minor", "patch" ]
+  schedule:
+    interval: "weekly"
+    day: "sunday"
+  labels:
+  - kind/dependency
+  - kind/chore
+- package-ecosystem: "npm"
+  directory: "/"
+  groups:
+    node:
+      update-types: [ "minor", "patch" ]
+  schedule:
+    interval: "weekly"
+    day: "sunday"
+  labels:
+  - kind/dependency
+  - kind/chore


### PR DESCRIPTION
#### What this PR does / why we need it

we should also configure `npm` updates