### PR TITLE
fix: add weight for generated cli reference

### DIFF
--- a/hack/generate-cli-docs/generate_markdown.go
+++ b/hack/generate-cli-docs/generate_markdown.go
@@ -3,14 +3,15 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/spf13/cobra"
 	"io"
-	"ocm.software/ocm/api/utils/cobrautils"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/spf13/cobra"
+	"ocm.software/ocm/api/utils/cobrautils"
 )
 
 const fmTmpl = `---
@@ -19,6 +20,7 @@ name: %s
 url: %s
 draft: false
 images: []
+weight: 55
 toc: true
 sidebar:
   collapsed: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Add weight for the side-bar folder "cli-reference" to sort it behind "Component Descriptors"

