### PR TITLE
chore: correct npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tabler/icons": "^3.30.0",
-        "@thulite/doks-core": "^1.8.1",
+        "@thulite/doks-core": "^1.8.0",
         "@thulite/images": "^3.3.0",
         "@thulite/inline-svg": "^1.2.0",
         "@thulite/seo": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@tabler/icons": "^3.30.0",
-    "@thulite/doks-core": "^1.8.1",
+    "@thulite/doks-core": "^1.8.0",
     "@thulite/images": "^3.3.0",
     "@thulite/inline-svg": "^1.2.0",
     "@thulite/seo": "^2.4.1",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
revert patch version for thulite doks-core package
