### PR TITLE
chore: add descriptor v2 vanity url

### DIFF
--- a/static/open-component-model/bindings/go/descriptor/v2
+++ b/static/open-component-model/bindings/go/descriptor/v2
@@ -1,0 +1,10 @@
+<html><head>
+  <meta name="go-import"
+        content="ocm.software/open-component-model
+                 git https://github.com/open-component-model/open-component-model">
+  <meta name="go-source"
+        content="ocm.software/open-component-model
+                 https://github.com/open-component-model/open-component-model
+                 https://github.com/open-component-model/open-component-model/tree/main{/dir}
+                 https://github.com/open-component-model/open-component-model/blob/main{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

create vanity for the v2 descriptor

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->