### PR TITLE
chore: make sure that credentials package is added to vanity urls so that go module resolution works for it

### DIFF
--- a/static/open-component-model/bindings/go/credentials
+++ b/static/open-component-model/bindings/go/credentials
@@ -1,0 +1,10 @@
+<html><head>
+  <meta name="go-import"
+        content="ocm.software/open-component-model
+                 git https://github.com/open-component-model/open-component-model">
+  <meta name="go-source"
+        content="ocm.software/open-component-model
+                 https://github.com/open-component-model/open-component-model
+                 https://github.com/open-component-model/open-component-model/tree/main{/dir}
+                 https://github.com/open-component-model/open-component-model/blob/main{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

makes it so `ocm.software/open-component-model/bindings/go/credentials` resolves correctly

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->