### PR TITLE
fix: update community URLs and add layout to community pages

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -5,7 +5,7 @@
 
 [[main]]
   name = "Community"
-  url = "/community/community"
+  url = "/community"
   weight = 20
 
 [[main]]

--- a/content/community/community.md
+++ b/content/community/community.md
@@ -1,12 +1,13 @@
 ---
 title: "The OCM Community"
 description: "The OCM Community"
-url: community/community
+url: /community
 lead: true
 draft: false
 images: []
 weight: 92
 toc: true
+layout: community
 ---
 
 ## How to engage with us

--- a/layouts/community/_markup/render-heading.html
+++ b/layouts/community/_markup/render-heading.html
@@ -1,3 +1,4 @@
 <h{{ .Level }} id="{{ .Anchor | safeURL }}">
-  {{- .Text | safeHTML -}}<a href="#{{ .Anchor | safeURL }}" class="anchor" aria-label="Permalink">#</a>
+  {{ .Text | safeHTML }}
+  <a href="#{{ .Anchor | safeURL }}" class="anchor" aria-hidden="true">#</a>
 </h{{ .Level }}>

--- a/layouts/community/_markup/render-heading.html
+++ b/layouts/community/_markup/render-heading.html
@@ -1,0 +1,3 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">
+  {{- .Text | safeHTML -}}<a href="#{{ .Anchor | safeURL }}" class="anchor" aria-label="Permalink">#</a>
+</h{{ .Level }}>

--- a/layouts/community/single.html
+++ b/layouts/community/single.html
@@ -7,7 +7,7 @@
           {{ .Content }}
         </div>
         <!-- TOC stays at 3/12 -->
-        <aside class="col-xl-3 docs-toc d-none d-xl-block">
+        <aside id="toc" class="col-xl-3 docs-toc d-none d-xl-block">
           {{ if .TableOfContents }}
             <h2 class="toc-title">On this page</h2>
             {{ .TableOfContents }}


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
re-introduce permalinks for the community page. These got lost, because we introduced a special rendering for the community side to make it centric, instead of attached to the left ,margin.