### PR TITLE
style: update logo colors for dark and light themes. Keep logo text in white always

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -79,6 +79,18 @@ header.navbar .ocm-logo {
   color: #ffffff !important;
 }
 
+/* === Force white logo text in header === */
+header.navbar .ocm-logo-text svg {
+  fill: #ffffff !important;
+  stroke: #ffffff !important;
+}
+
+/* === Force white logo text in section start area (e.g. front page) === */
+.section .ocm-logo-text svg {
+  fill: #ffffff !important;
+  stroke: #ffffff !important;
+}
+
 /* === Theme-dependent color for center logo on start page === */
 [data-bs-theme="dark"] .font-logo {
   color: #ffffff !important;  // White in dark mode

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -65,7 +65,15 @@ header.navbar .nav-link[aria-label="Search website"] svg {
 }
 
 /* === Logo icon and text SVG styling === */
-.ocm-logo-icon svg,
+.ocm-logo-icon svg {
+  height: 42px;
+  width: auto;
+  display: block;
+  /* Allow native colors inside icon SVG */
+  fill: unset !important;
+  stroke: unset !important;
+}
+
 .ocm-logo-text svg {
   height: 42px;
   width: auto;

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -64,18 +64,30 @@ header.navbar .nav-link[aria-label="Search website"] svg {
   fill: none;
 }
 
-// Logo color follows header text color
-.ocm-logo {
-  color: #dee2e6 !important;
-}
-
-// Size and layout for SVG logos
+/* === Logo icon and text SVG styling === */
 .ocm-logo-icon svg,
 .ocm-logo-text svg {
   height: 42px;
   width: auto;
   display: block;
+  fill: currentColor;
+  stroke: currentColor;
 }
+
+/* === Force white logo color in the header === */
+header.navbar .ocm-logo {
+  color: #ffffff !important;
+}
+
+/* === Theme-dependent color for center logo on start page === */
+[data-bs-theme="dark"] .font-logo {
+  color: #ffffff !important;  // White in dark mode
+}
+
+[data-bs-theme="light"] .font-logo {
+  color: #111111 !important;  // Dark text in light mode
+}
+
 
 
 /* ============================================


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
The grey logo text in header and on main page should be clear white, not light grey.