### PR TITLE
chore: reduce concurrency setting in linkinator configuration

### DIFF
--- a/.github/config/linkinator.json
+++ b/.github/config/linkinator.json
@@ -1,5 +1,5 @@
 {
-  "concurrency": 5,
+  "concurrency": 2,
   "recurse": true,
   "verbosity": "warning",
   "timeout": 20000,


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
reduce concurrency even further to avoid 429 errors from GitHub...