### PR TITLE
chore: update linkinator configuration and change markdown checks like in open-component-model repo

### DIFF
--- a/.github/config/linkinator.json
+++ b/.github/config/linkinator.json
@@ -1,5 +1,5 @@
 {
-  "concurrency": 2,
+  "concurrency": 100,
   "recurse": true,
   "verbosity": "warning",
   "timeout": 20000,
@@ -10,7 +10,6 @@
   "skip": [
     "^https?://(www\\.)?gitea\\.ocm\\.dev(/|$)",
     "^https://.*\\.ocm\\.dev(/|$)",
-    "^https://github\\.com/open-component-model/ocm/blob/main/docs/reference/.*",
-    "^https://github\\.com/open-component-model/open-component-model/blob/main/docs/reference.*"
+    "^https://github\\.com/.*"
   ]
 }

--- a/.github/config/linkspector.yml
+++ b/.github/config/linkspector.yml
@@ -1,0 +1,5 @@
+dirs:
+  - ./
+replacementPatterns:
+  - pattern: "^/"
+    replacement: "{{BASEURL}}/"

--- a/.github/config/markdownlint-cli2.yml
+++ b/.github/config/markdownlint-cli2.yml
@@ -1,0 +1,12 @@
+#yaml-language-server: $schema=https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/refs/heads/main/schema/markdownlint-cli2-config-schema.json
+config:
+  default: true
+  MD001: false #Heading style - Allow heading levels to be incremented by multiple levels at a time
+  MD013: false #Line length - https://github.com/DavidAnson/markdownlint/blob/HEAD/doc/Rules.md#md013
+  MD033: false #Inline HTML - https://github.com/DavidAnson/markdownlint/blob/HEAD/doc/Rules.md#md033
+  MD024:
+    siblings_only: true #Multiple headers with the same content
+  MD009: false #no-trailing-spaces Trailing spaces
+  MD004: false #Unordered list style
+  MD031: false #Fenced code blocks should be surrounded by blank lines
+  MD036: false #No emphasis added

--- a/.github/config/markdownlint.yml
+++ b/.github/config/markdownlint.yml
@@ -1,7 +1,0 @@
-default: true
-
-MD001: false #Heading style - Allow heading levels to be incremented by multiple levels at a time
-MD013: false #Line length - https://github.com/DavidAnson/markdownlint/blob/HEAD/doc/Rules.md#md013
-MD033: false #Inline HTML - https://github.com/DavidAnson/markdownlint/blob/HEAD/doc/Rules.md#md033
-MD024:
-  siblings_only: true #Multiple headers with the same content

--- a/.github/workflows/verify-html.yml
+++ b/.github/workflows/verify-html.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check-links:
-    name: Check external and internal links (Netlify Deploy Preview)
+    name: Check external links (Netlify Deploy Preview)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/verify-html.yml
+++ b/.github/workflows/verify-html.yml
@@ -1,4 +1,4 @@
-name: Verify HTML Links
+name: Verify HTML Links on rendered website
 
 on:
   pull_request:
@@ -14,7 +14,9 @@ jobs:
     name: Check external and internal links (Netlify Deploy Preview)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0 # fetch all history for the PR
 
       - name: Wait for Netlify Deploy Preview
         id: wait_for_preview
@@ -76,7 +78,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.12.0 # keep in sync with 'engines'@package.json
 

--- a/.github/workflows/verify-markdown.yml
+++ b/.github/workflows/verify-markdown.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - '**/*.md'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-markdown.yml
+++ b/.github/workflows/verify-markdown.yml
@@ -1,4 +1,4 @@
-name: Markdown
+name: Verify Markdown
 
 on:
   pull_request:
@@ -7,14 +7,39 @@ on:
     paths:
       - '**/*.md'
 
-permissions:
-  contents: read
-
 jobs:
-  check-md: # call reusable workflow from central '.github' repo
-    uses: open-component-model/.github/.github/workflows/markdown.yml@main
-    secrets: inherit
-    with:
-      md-lint: .github/config/markdownlint.yml
-      md-ignore: .github/config/markdownignore
-      spellcheck: .github/config/spellcheck.yml
+  markdown-lint:
+    runs-on: ubuntu-latest
+    name: Lint Markdown
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20
+        with:
+          globs: '**/*.md'
+          separator: ","
+          config: .github/config/.markdownlint-cli2.yaml
+  verify-links:
+    name: Verify links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@3a951c1f0dca72300c2320d0eb39c2bafe429ab1 # v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          fail_level: any
+          config_file: .github/config/linkspector.yaml
+          show_stats: true
+  spellcheck:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Spellcheck
+        uses: rojopolis/spellcheck-github-actions@35a02bae020e6999c5c37fabaf447f2eb8822ca7 # v0
+        with:
+          config_path: .github/config/spellcheck.yml
+          task_name: Markdown
+
+


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Due to issues with rate limits when checking links on gihub.com, we disabled link checking for GitHub.com. In addition to that we added broken link check using linkspector.