### PR TITLE
chore: switch off md059 markdown check. sort markdownlint rules.

### DIFF
--- a/.github/config/.markdownlint-cli2.yaml
+++ b/.github/config/.markdownlint-cli2.yaml
@@ -2,11 +2,12 @@
 config:
   default: true
   MD001: false #Heading style - Allow heading levels to be incremented by multiple levels at a time
+  MD004: false #Unordered list style
+  MD009: false #no-trailing-spaces Trailing spaces
   MD013: false #Line length - https://github.com/DavidAnson/markdownlint/blob/HEAD/doc/Rules.md#md013
-  MD033: false #Inline HTML - https://github.com/DavidAnson/markdownlint/blob/HEAD/doc/Rules.md#md033
   MD024:
     siblings_only: true #Multiple headers with the same content
-  MD009: false #no-trailing-spaces Trailing spaces
-  MD004: false #Unordered list style
   MD031: false #Fenced code blocks should be surrounded by blank lines
+  MD033: false #Inline HTML - https://github.com/DavidAnson/markdownlint/blob/HEAD/doc/Rules.md#md033
   MD036: false #No emphasis added
+  MD059: false #Link text should be descriptive - https://github.com/DavidAnson/markdownlint/blob/main/doc/md059.md


### PR DESCRIPTION


On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
MD059 switched off for website documents.