### PR TITLE
chore(docs): standardize header levels in community.md

### DIFF
--- a/content/community/community.md
+++ b/content/community/community.md
@@ -10,11 +10,11 @@ layout: community
 
 The Open Component Model is developed in the open. Here are some of the channels we use to communicate and contribute:
 
-#### GitHub
+### GitHub
 
 Our GitHub repositories are the central hub for all project development. Connect with our codebase, report issues, submit pull requests, and follow our project's progress. New contributors can find issues labeled `good first issue` to get started, and our detailed [contribution guidelines](#contributing) will help you make your first successful submission.
 
-#### Slack
+### Slack
 
 Join our [#open-component-model](https://kubernetes.slack.com/archives/C05UWBE8R1D) channel in the Kubernetes Slack workspace and connect with us and other community members.
 
@@ -22,26 +22,26 @@ Join our [#open-component-model](https://kubernetes.slack.com/archives/C05UWBE8R
 
 Our team is passionate about delving into diverse deployment processes, exploring patterns, aiding in design, and troubleshooting issues. Who knows? Your inquiry might inspire the development of the next useful OCM feature!
 
-#### Community Calls
+### Community Calls
 
 We're excited to announce our regular community calls:
 
-##### Schedule
+#### Schedule
 
 - **Frequency**: Every first Wednesday of the months
 - **Time**: 15:00-16:00 UTC (17:00-18:00 CEST, 11:00-12:00 EDT, 08:00-09:00 PDT)
 - **Duration**: 1 hour
 - **Location**: Use this [Zoom Link](https://zoom-lfx.platform.linuxfoundation.org/meeting/97987153840?password=fe2c3bf0-6a99-4e75-b62d-f1918154254e) to join the call.
 
-##### iCal (Apple/Outlook)
+#### iCal (Apple/Outlook)
 
 Download the [.ics file](/ocm-community.ics) to add the community call meeting series to your calendar.
 
-##### Call History
+#### Call History
 
 [This page](https://github.com/open-component-model/open-component-model/blob/main/docs/community/README.md) contains the history of the Open Component Model community calls and links to slides and recordings.
 
-##### What to Expect
+#### What to Expect
 
 Join us to see and discuss project updates, share your feedback, ask questions, and connect with other community members.
 The community calls should be an open discussion space and give a voice to any interested stakeholder.
@@ -50,7 +50,7 @@ At the same time we want our community to be diverse, helpful, collaborative and
 These calls are open to everyone and will be moderated by at least one OCM Core Maintainer.
 We will answer anything you might bring up!
 
-##### What to Bring
+#### What to Bring
 
 We want to hear from you! This is your chance to share your thoughts and ideas with the community.
 You can bring anything, including:
@@ -60,15 +60,15 @@ You can bring anything, including:
 - Concepts you would like to work on together
 - Questions you have about the community or upcoming work
 
-### Contributing
+## Contributing
 
 We welcome community contributions! Please see the [Contributing Guideline](https://github.com/open-component-model/.github/blob/main/CONTRIBUTING.md) for instructions on how to submit changes. If you are planning on making more elaborate or potentially controversial changes, please discuss them with the maintainers in the [Slack channel](https://kubernetes.slack.com/archives/C05UWBE8R1D) before sending a pull request.
 
-### Code of Conduct
+## Code of Conduct
 
 To make OCM a welcoming and harassment-free experience for everyone, we follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-### Security Guideline
+## Security Guideline
 
 In case you want to report any security vulnerabilities inside the Open Component Model project,
 please do not report them through public GitHub issues.


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
The current header sizes do not fit and lead to a wrong display in the TOC. That has been corrected now.