### PR TITLE
chore: update markdown linting configuration to exclude specific reference directories

### DIFF
--- a/.github/workflows/verify-markdown.yml
+++ b/.github/workflows/verify-markdown.yml
@@ -19,8 +19,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20
         with:
-          globs: '**/*.md'
-          separator: ","
+          globs: |
+            **/*.md
+            !content/docs/reference/ocm-cli
+            !content/docs/reference/ocm-controller
           config: .github/config/.markdownlint-cli2.yaml
 
   spellcheck:


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>
Signed-off-by: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
exclude ocm v1 ref docs from markdown linter