### PR TITLE
fix: update titles and names in CLI documentation for consistency

### DIFF
--- a/content/docs/reference/ocm-cli/add/add_componentversions.md
+++ b/content/docs/reference/ocm-cli/add/add_componentversions.md
@@ -1,6 +1,6 @@
 ---
-title: componentversions
-name: add componentversions
+title: add componentversions
+name: componentversions
 url: /docs/reference/ocm-cli/add/componentversions/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/add/add_references.md
+++ b/content/docs/reference/ocm-cli/add/add_references.md
@@ -1,6 +1,6 @@
 ---
-title: references
-name: add references
+title: add references
+name: references
 url: /docs/reference/ocm-cli/add/references/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/add/add_resource-configuration.md
+++ b/content/docs/reference/ocm-cli/add/add_resource-configuration.md
@@ -1,6 +1,6 @@
 ---
-title: resource-configuration
-name: add resource-configuration
+title: add resource-configuration
+name: resource-configuration
 url: /docs/reference/ocm-cli/add/resource-configuration/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/add/add_resources.md
+++ b/content/docs/reference/ocm-cli/add/add_resources.md
@@ -1,6 +1,6 @@
 ---
-title: resources
-name: add resources
+title: add resources
+name: resources
 url: /docs/reference/ocm-cli/add/resources/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/add/add_routingslips.md
+++ b/content/docs/reference/ocm-cli/add/add_routingslips.md
@@ -1,6 +1,6 @@
 ---
-title: routingslips
-name: add routingslips
+title: add routingslips
+name: routingslips
 url: /docs/reference/ocm-cli/add/routingslips/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/add/add_source-configuration.md
+++ b/content/docs/reference/ocm-cli/add/add_source-configuration.md
@@ -1,6 +1,6 @@
 ---
-title: source-configuration
-name: add source-configuration
+title: add source-configuration
+name: source-configuration
 url: /docs/reference/ocm-cli/add/source-configuration/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/add/add_sources.md
+++ b/content/docs/reference/ocm-cli/add/add_sources.md
@@ -1,6 +1,6 @@
 ---
-title: sources
-name: add sources
+title: add sources
+name: sources
 url: /docs/reference/ocm-cli/add/sources/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/check/check_componentversions.md
+++ b/content/docs/reference/ocm-cli/check/check_componentversions.md
@@ -1,6 +1,6 @@
 ---
-title: componentversions
-name: check componentversions
+title: check componentversions
+name: componentversions
 url: /docs/reference/ocm-cli/check/componentversions/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/clean/clean_cache.md
+++ b/content/docs/reference/ocm-cli/clean/clean_cache.md
@@ -1,6 +1,6 @@
 ---
-title: cache
-name: clean cache
+title: clean cache
+name: cache
 url: /docs/reference/ocm-cli/clean/cache/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/create/create_componentarchive.md
+++ b/content/docs/reference/ocm-cli/create/create_componentarchive.md
@@ -1,6 +1,6 @@
 ---
-title: componentarchive
-name: create componentarchive
+title: create componentarchive
+name: componentarchive
 url: /docs/reference/ocm-cli/create/componentarchive/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/create/create_rsakeypair.md
+++ b/content/docs/reference/ocm-cli/create/create_rsakeypair.md
@@ -1,6 +1,6 @@
 ---
-title: rsakeypair
-name: create rsakeypair
+title: create rsakeypair
+name: rsakeypair
 url: /docs/reference/ocm-cli/create/rsakeypair/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/create/create_transportarchive.md
+++ b/content/docs/reference/ocm-cli/create/create_transportarchive.md
@@ -1,6 +1,6 @@
 ---
-title: transportarchive
-name: create transportarchive
+title: create transportarchive
+name: transportarchive
 url: /docs/reference/ocm-cli/create/transportarchive/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/describe/describe_artifacts.md
+++ b/content/docs/reference/ocm-cli/describe/describe_artifacts.md
@@ -1,6 +1,6 @@
 ---
-title: artifacts
-name: describe artifacts
+title: describe artifacts
+name: artifacts
 url: /docs/reference/ocm-cli/describe/artifacts/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/describe/describe_cache.md
+++ b/content/docs/reference/ocm-cli/describe/describe_cache.md
@@ -1,6 +1,6 @@
 ---
-title: cache
-name: describe cache
+title: describe cache
+name: cache
 url: /docs/reference/ocm-cli/describe/cache/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/describe/describe_package.md
+++ b/content/docs/reference/ocm-cli/describe/describe_package.md
@@ -1,6 +1,6 @@
 ---
-title: package
-name: describe package
+title: describe package
+name: package
 url: /docs/reference/ocm-cli/describe/package/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/describe/describe_plugins.md
+++ b/content/docs/reference/ocm-cli/describe/describe_plugins.md
@@ -1,6 +1,6 @@
 ---
-title: plugins
-name: describe plugins
+title: describe plugins
+name: plugins
 url: /docs/reference/ocm-cli/describe/plugins/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/download/download_artifacts.md
+++ b/content/docs/reference/ocm-cli/download/download_artifacts.md
@@ -1,6 +1,6 @@
 ---
-title: artifacts
-name: download artifacts
+title: download artifacts
+name: artifacts
 url: /docs/reference/ocm-cli/download/artifacts/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/download/download_cli.md
+++ b/content/docs/reference/ocm-cli/download/download_cli.md
@@ -1,6 +1,6 @@
 ---
-title: cli
-name: download cli
+title: download cli
+name: cli
 url: /docs/reference/ocm-cli/download/cli/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/download/download_componentversions.md
+++ b/content/docs/reference/ocm-cli/download/download_componentversions.md
@@ -1,6 +1,6 @@
 ---
-title: componentversions
-name: download componentversions
+title: download componentversions
+name: componentversions
 url: /docs/reference/ocm-cli/download/componentversions/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/download/download_resources.md
+++ b/content/docs/reference/ocm-cli/download/download_resources.md
@@ -1,6 +1,6 @@
 ---
-title: resources
-name: download resources
+title: download resources
+name: resources
 url: /docs/reference/ocm-cli/download/resources/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_artifacts.md
+++ b/content/docs/reference/ocm-cli/get/get_artifacts.md
@@ -1,6 +1,6 @@
 ---
-title: artifacts
-name: get artifacts
+title: get artifacts
+name: artifacts
 url: /docs/reference/ocm-cli/get/artifacts/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_componentversions.md
+++ b/content/docs/reference/ocm-cli/get/get_componentversions.md
@@ -1,6 +1,6 @@
 ---
-title: componentversions
-name: get componentversions
+title: get componentversions
+name: componentversions
 url: /docs/reference/ocm-cli/get/componentversions/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_config.md
+++ b/content/docs/reference/ocm-cli/get/get_config.md
@@ -1,6 +1,6 @@
 ---
-title: config
-name: get config
+title: get config
+name: config
 url: /docs/reference/ocm-cli/get/config/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_credentials.md
+++ b/content/docs/reference/ocm-cli/get/get_credentials.md
@@ -1,6 +1,6 @@
 ---
-title: credentials
-name: get credentials
+title: get credentials
+name: credentials
 url: /docs/reference/ocm-cli/get/credentials/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_plugins.md
+++ b/content/docs/reference/ocm-cli/get/get_plugins.md
@@ -1,6 +1,6 @@
 ---
-title: plugins
-name: get plugins
+title: get plugins
+name: plugins
 url: /docs/reference/ocm-cli/get/plugins/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_pubsub.md
+++ b/content/docs/reference/ocm-cli/get/get_pubsub.md
@@ -1,6 +1,6 @@
 ---
-title: pubsub
-name: get pubsub
+title: get pubsub
+name: pubsub
 url: /docs/reference/ocm-cli/get/pubsub/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_references.md
+++ b/content/docs/reference/ocm-cli/get/get_references.md
@@ -1,6 +1,6 @@
 ---
-title: references
-name: get references
+title: get references
+name: references
 url: /docs/reference/ocm-cli/get/references/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_resources.md
+++ b/content/docs/reference/ocm-cli/get/get_resources.md
@@ -1,6 +1,6 @@
 ---
-title: resources
-name: get resources
+title: get resources
+name: resources
 url: /docs/reference/ocm-cli/get/resources/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_routingslips.md
+++ b/content/docs/reference/ocm-cli/get/get_routingslips.md
@@ -1,6 +1,6 @@
 ---
-title: routingslips
-name: get routingslips
+title: get routingslips
+name: routingslips
 url: /docs/reference/ocm-cli/get/routingslips/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_sources.md
+++ b/content/docs/reference/ocm-cli/get/get_sources.md
@@ -1,6 +1,6 @@
 ---
-title: sources
-name: get sources
+title: get sources
+name: sources
 url: /docs/reference/ocm-cli/get/sources/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/get/get_verified.md
+++ b/content/docs/reference/ocm-cli/get/get_verified.md
@@ -1,6 +1,6 @@
 ---
-title: verified
-name: get verified
+title: get verified
+name: verified
 url: /docs/reference/ocm-cli/get/verified/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/list/list_componentversions.md
+++ b/content/docs/reference/ocm-cli/list/list_componentversions.md
@@ -1,6 +1,6 @@
 ---
-title: componentversions
-name: list componentversions
+title: list componentversions
+name: componentversions
 url: /docs/reference/ocm-cli/list/componentversions/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/set/set_pubsub.md
+++ b/content/docs/reference/ocm-cli/set/set_pubsub.md
@@ -1,6 +1,6 @@
 ---
-title: pubsub
-name: set pubsub
+title: set pubsub
+name: pubsub
 url: /docs/reference/ocm-cli/set/pubsub/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/show/show_tags.md
+++ b/content/docs/reference/ocm-cli/show/show_tags.md
@@ -1,6 +1,6 @@
 ---
-title: tags
-name: show tags
+title: show tags
+name: tags
 url: /docs/reference/ocm-cli/show/tags/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/show/show_versions.md
+++ b/content/docs/reference/ocm-cli/show/show_versions.md
@@ -1,6 +1,6 @@
 ---
-title: versions
-name: show versions
+title: show versions
+name: versions
 url: /docs/reference/ocm-cli/show/versions/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/sign/sign_componentversions.md
+++ b/content/docs/reference/ocm-cli/sign/sign_componentversions.md
@@ -1,6 +1,6 @@
 ---
-title: componentversions
-name: sign componentversions
+title: sign componentversions
+name: componentversions
 url: /docs/reference/ocm-cli/sign/componentversions/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/sign/sign_hash.md
+++ b/content/docs/reference/ocm-cli/sign/sign_hash.md
@@ -1,6 +1,6 @@
 ---
-title: hash
-name: sign hash
+title: sign hash
+name: hash
 url: /docs/reference/ocm-cli/sign/hash/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/transfer/transfer_artifacts.md
+++ b/content/docs/reference/ocm-cli/transfer/transfer_artifacts.md
@@ -1,6 +1,6 @@
 ---
-title: artifacts
-name: transfer artifacts
+title: transfer artifacts
+name: artifacts
 url: /docs/reference/ocm-cli/transfer/artifacts/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/transfer/transfer_commontransportarchive.md
+++ b/content/docs/reference/ocm-cli/transfer/transfer_commontransportarchive.md
@@ -1,6 +1,6 @@
 ---
-title: commontransportarchive
-name: transfer commontransportarchive
+title: transfer commontransportarchive
+name: commontransportarchive
 url: /docs/reference/ocm-cli/transfer/commontransportarchive/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/transfer/transfer_componentarchive.md
+++ b/content/docs/reference/ocm-cli/transfer/transfer_componentarchive.md
@@ -1,6 +1,6 @@
 ---
-title: componentarchive
-name: transfer componentarchive
+title: transfer componentarchive
+name: componentarchive
 url: /docs/reference/ocm-cli/transfer/componentarchive/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/transfer/transfer_componentversions.md
+++ b/content/docs/reference/ocm-cli/transfer/transfer_componentversions.md
@@ -1,6 +1,6 @@
 ---
-title: componentversions
-name: transfer componentversions
+title: transfer componentversions
+name: componentversions
 url: /docs/reference/ocm-cli/transfer/componentversions/
 draft: false
 images: []

--- a/content/docs/reference/ocm-cli/verify/verify_componentversions.md
+++ b/content/docs/reference/ocm-cli/verify/verify_componentversions.md
@@ -1,6 +1,6 @@
 ---
-title: componentversions
-name: verify componentversions
+title: verify componentversions
+name: componentversions
 url: /docs/reference/ocm-cli/verify/componentversions/
 draft: false
 images: []

--- a/hack/generate-cli-docs/generate_markdown.go
+++ b/hack/generate-cli-docs/generate_markdown.go
@@ -84,23 +84,23 @@ func genMarkdownTreeCustom(cmd *cobra.Command, dir, urlPrefix, parentCmd string)
 
 	frontmatter := func() string {
 		cmdName := commandToID(cmd.Name())
-		title := strings.TrimSuffix(cmdName, path.Ext(cmdName))
-		var url, name string
+		shortName := strings.TrimSuffix(cmdName, path.Ext(cmdName))
+		var url, title string
 		if cmd.IsAdditionalHelpTopicCommand() {
-			url = urlPrefix + "help/" + strings.ToLower(title) + "/"
-			name = title
+			url = urlPrefix + "help/" + strings.ToLower(shortName) + "/"
+			title = shortName
 		} else if cmdName == "ocm-cli" {
 			url = urlPrefix
 			title = "OCM CLI"
-			name = "OCM CLI"
+			shortName = "OCM CLI"
 		} else if parentCmd == "ocm-cli" {
-			url = urlPrefix + strings.ToLower(title) + "/"
-			name = title
+			url = urlPrefix + strings.ToLower(shortName) + "/"
+			title = shortName
 		} else {
-			url = urlPrefix + parentCmd + "/" + strings.ToLower(title) + "/"
-			name = fmt.Sprintf("%s %s", parentCmd, title)
+			url = urlPrefix + parentCmd + "/" + strings.ToLower(shortName) + "/"
+			title = fmt.Sprintf("%s %s", parentCmd, shortName)
 		}
-		return fmt.Sprintf(fmTmpl, title, name, url)
+		return fmt.Sprintf(fmTmpl, title, shortName, url)
 	}
 
 	if _, err := io.WriteString(f, frontmatter()); err != nil {


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>
Signed-off-by: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
currently navigation prev/next is broken. "title" and "name" in the frontmatter are mixed up. This fix corrects that.