### PR TITLE
chore: update branch filter in publish-site workflow to include website/**

### DIFF
--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -3,7 +3,9 @@ name: Publish Site
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches:
+      - main
+      - website/**
 
 env:
   OUTPUT_DIR: site-docs/


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
With the new setup of a multi-version website, pushes to all branches (main and website/**) need to trigger a publish of the website.