### PR TITLE
chore: add normalisation module (#571)

### DIFF
--- a/static/open-component-model/bindings/go/descriptor/normalisation
+++ b/static/open-component-model/bindings/go/descriptor/normalisation
@@ -1,0 +1,10 @@
+<html><head>
+  <meta name="go-import"
+        content="ocm.software/open-component-model
+                 git https://github.com/open-component-model/open-component-model">
+  <meta name="go-source"
+        content="ocm.software/open-component-model
+                 https://github.com/open-component-model/open-component-model
+                 https://github.com/open-component-model/open-component-model/tree/main{/dir}
+                 https://github.com/open-component-model/open-component-model/blob/main{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
We need this to be able to import packages from the normalisation module.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->


(cherry picked from commit 5ffcd746677433a4a904f6a12bf8b148850bf46a)