### PR TITLE
fix: update cli docs action

### DIFF
--- a/.github/workflows/update-cli-docs.yaml
+++ b/.github/workflows/update-cli-docs.yaml
@@ -9,9 +9,6 @@ on:
   repository_dispatch:
     types: [ocm-cli-release]
 
-env:
-  OUTPUT_DIR: ./content/docs/reference/ocm-cli
-
 jobs:
   generate-cli-reference:
     name: Update content/docs/reference/ocm-cli
@@ -31,6 +28,18 @@ jobs:
         TAG=${{ github.event.client_payload.tag }}
         sed -i "s/latest_version = .*/latest_version = \"$TAG\"/" ./config/_default/params.toml
 
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: '${{ github.workspace }}/hack/generate-cli-docs/go.mod'
+
+    - name: Regenerate CLI docs
+      run: |
+        cd ./hack/generate-cli-docs
+        go get ocm.software/ocm@${{ github.event.client_payload.tag }}
+        go mod tidy
+        go run ./hack/generate-cli-docs --output-dir=${{ github.workspace }}/content/docs/reference/ocm-cli
+
     - name: Get OCMBot installation token
       # Instead of creating the PR below with GITHUB_TOKEN use a generated
       # short-lived App installation token with full REST rights
@@ -49,8 +58,8 @@ jobs:
         add-paths: |
           config/
           content/
-          go.mod
-          go.sum
+          hack/generate-cli-docs/go.mod
+          hack/generate-cli-docs/go.sum
         branch: update-cli-docs/auto
         branch-suffix: timestamp
         delete-branch: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
We broke the current cli docs action in 2 ways:
- creating an own go.mod file for the hack scripts broke the current cli docs action
- we accidentally deleted a part from current that was only obsolete on main

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->