### PR TITLE
chore(docs): add Special Interest Groups (SIGs) section to community guidelines

### DIFF
--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -431,4 +431,6 @@ zshrc
 bashrc
 argocd
 relref
-
+sig
+sig's
+sigs

--- a/content/community/community.md
+++ b/content/community/community.md
@@ -72,7 +72,9 @@ To make OCM a welcoming and harassment-free experience for everyone, we follow t
 
 OCM grows when people build together — and our Special Interest Groups (SIGs) are where ideas turn into impact.
 
-SIGs are focused working groups that take ownership of a specific area of the project and move it forward. Following the example of other CNCF projects, we defined a framework for SIGs to help contributors collaborate effectively.
+SIGs are focused working groups that take ownership of a specific area of the project and move it forward.
+
+Following the example of other CNCF projects, we defined a framework for SIGs to help contributors collaborate effectively.
 
 The **[SIG Handbook](https://github.com/open-component-model/open-component-model/blob/main/docs/community/SIGs/SIG-Handbook.md)** covers:
 

--- a/content/community/community.md
+++ b/content/community/community.md
@@ -70,18 +70,23 @@ To make OCM a welcoming and harassment-free experience for everyone, we follow t
 
 ## Special Interest Groups (SIGs)
 
-To organize contributions to OCM in a structured and topic-focused way, we have defined a **framework for Special Interest Groups (SIGs)**.  
-SIGs are specialized working groups that take responsibility for particular areas of the OCM project.
+OCM grows when people build together — and our Special Interest Groups (SIGs) are where ideas turn into impact.
 
-The **[SIG Handbook](https://github.com/open-component-model/open-component-model/blob/main/docs/community/SIGs/SIG-Handbook.md)** describes:
+SIGs are focused working groups that take ownership of a specific area of the project and move it forward. Following the example of other CNCF projects, we defined a framework for SIGs to help contributors collaborate effectively.
 
-- the goals and motivation behind SIGs  
-- roles and responsibilities  
-- processes for establishing and running a SIG  
+The **[SIG Handbook](https://github.com/open-component-model/open-component-model/blob/main/docs/community/SIGs/SIG-Handbook.md)** covers:
 
-At this point, we are still in the **introduction phase**: there are no active SIGs yet. Once the first groups are established, we will list them here.
+- goals and motivation behind SIGs
+- roles and responsibilities
+- how to propose, establish, and run a SIG
 
-If you are interested in contributing to the setup or in joining a SIG later, please start by reading the [SIG Handbook](https://github.com/open-component-model/open-component-model/tree/main/docs/community/SIGs).
+> **Status:** We’re in the kick-off phase — there are no active SIGs *yet*. That’s your chance to shape the very first ones! As SIGs form, we’ll list them here.
+
+### How to get involved
+
+- **Curious?** Start with the [SIG Handbook](https://github.com/open-component-model/open-component-model/blob/main/docs/community/SIGs/SIG-Handbook.md).  
+- **Have a topic in mind?** Follow the handbook’s steps to **propose a SIG** and gather interested contributors.  
+- **Prefer to join later?** Keep an eye on this page — we’ll announce and list new SIGs here.
 
 ## Security Guideline
 

--- a/content/community/community.md
+++ b/content/community/community.md
@@ -68,6 +68,21 @@ We welcome community contributions! Please see the [Contributing Guideline](http
 
 To make OCM a welcoming and harassment-free experience for everyone, we follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
+## Special Interest Groups (SIGs)
+
+To organize contributions to OCM in a structured and topic-focused way, we have defined a **framework for Special Interest Groups (SIGs)**.  
+SIGs are specialized working groups that take responsibility for particular areas of the OCM project.
+
+The **[SIG Handbook](https://github.com/open-component-model/open-component-model/blob/main/docs/community/SIGs/SIG-Handbook.md)** describes:
+
+- the goals and motivation behind SIGs  
+- roles and responsibilities  
+- processes for establishing and running a SIG  
+
+At this point, we are still in the **introduction phase**: there are no active SIGs yet. Once the first groups are established, we will list them here.
+
+If you are interested in contributing to the setup or in joining a SIG later, please start by reading the [SIG Handbook](https://github.com/open-component-model/open-component-model/tree/main/docs/community/SIGs).
+
 ## Security Guideline
 
 In case you want to report any security vulnerabilities inside the Open Component Model project,

--- a/static/open-component-model/bindings/go/rsa
+++ b/static/open-component-model/bindings/go/rsa
@@ -1,0 +1,10 @@
+<html><head>
+  <meta name="go-import"
+        content="ocm.software/open-component-model
+                 git https://github.com/open-component-model/open-component-model">
+  <meta name="go-source"
+        content="ocm.software/open-component-model
+                 https://github.com/open-component-model/open-component-model
+                 https://github.com/open-component-model/open-component-model/tree/main{/dir}
+                 https://github.com/open-component-model/open-component-model/blob/main{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Add a section for SIGs to the community page.