### PR TITLE
fix: correct module update logic and update docs

### DIFF
--- a/.github/docs/how-to-create-new-docs.md
+++ b/.github/docs/how-to-create-new-docs.md
@@ -2,12 +2,12 @@
 
 ## 🎯 Objective and Summary
 
-This document describes how to create and test new content for our OCM website, including impüorting content from other repositories, e.g. `ocm` or `open-component-model` using Hugo modules.
+This document describes how to create and test new content for our OCM website, including importing content from other repositories, e.g. `ocm` or `open-component-model` using Hugo modules.
 
 The website utilizes:
 
 - **Frontmatter** for each document to define metadata like title, description, and logo. The templates are stored in `.github/templates/`.
-- **Version Branches** (e.g., `releases/website/v1.0`) for each released version of the website. New content is created in branch `main`, and then branched to the respective website version branch when we release a new OCM version. Corrections and updates to existing content are made in the release branch and are then cherry-picked to the `main` branch.
+- **Version Branches** (e.g., `releases/website/v1.0`) for each released version of the website. New content is created in branch `main`, and then branched to the respective website version branch when we release a new OCM version. Corrections and updates to existing content are made in the `main`branch and then cherry-picked into the release branch.
 - **Hugo Modules** to include the reference documentation for CLI, APIs and other content from other repositories.
 
 ## 📚 Content Creation
@@ -35,7 +35,7 @@ A section page is a special type of content page that serves as a landing page f
 
 ### 🔗 Import Content from other locations
 
-*Adding new references to other repositories is a very rare action. Most-likely we will only have two referenced modules, one for the CLI and for the controllers.*
+*Adding new references to other repositories is a very rare action. Most-likely we will only have two referenced modules, one for the CLI and one for the controllers.*
 
 A new module MUST only be created in combination a new website version. To include a new references you can use Hugo modules. The configuration is done in `config/_default/module.toml`. You can define the modules to be used and where they should be mounted in the website. Here's an example for the OCM CLI reference documentation:
 
@@ -45,6 +45,13 @@ path = "ocm.software/open-component-model/cli"
   [[imports.mounts]]
     source = "docs/reference"
     target = "content/docs/reference/ocm-cli"
+
+### not available yet, but planned
+#[[imports]]
+#path = "ocm.software/open-component-model/kubernetes/controller"
+#  [[imports.mounts]]
+#    source = "docs/reference"
+#    target = "content/docs/reference/ocm-controller"
 ```
 
 This configuration mounts the `docs/reference` directory from the OCM CLI repository into the `content/docs/reference/ocm-cli` directory of the website. You can add multiple modules as needed.

--- a/.github/scripts/build-multi-version.sh
+++ b/.github/scripts/build-multi-version.sh
@@ -204,6 +204,35 @@ WORKTREE_BASE=".worktrees"
 rm -rf "$WORKTREE_BASE"
 mkdir -p "$WORKTREE_BASE"
 
+# read all Hugo module imports for updating modules in "dev" version
+get_hugo_imports() {
+  npm run hugo -- --logLevel error config --format json \
+    | jq -r '.[].module.imports[]?.path' 2>/dev/null \
+    | sort -u
+}
+
+# Update Hugo modules for a given version
+# For "dev" version, set each module explicitly to @main to get latest changes
+# For other versions, use pinned go.mod without changes
+update_modules_for_version() {
+  local ver="$1"
+  if [ "$ver" = "dev" ]; then
+    info "DEV: set each Hugo module to @main"
+    local modules
+    modules=$(get_hugo_imports || true)
+    if [ -n "$modules" ]; then
+      for m in $modules; do
+        npm run hugo -- mod get "${m}@main" || { err "hugo mod get ${m}@main failed"; return 1; }
+      done
+    else
+      info "No module imports found in effective config."
+    fi
+    npm run hugo -- mod tidy || { err "hugo mod tidy failed"; return 1; }
+  else
+    info "Non-DEV: using pinned go.mod (no module actions)"
+    :
+  fi
+}
 
 # Build each version listed in versions.json
 # BUILT_VERSIONS will hold the mapping: version -> output directory
@@ -239,9 +268,9 @@ for VERSION in $VERSIONS; do
 
     # Make npm clean install (using the package-lock.json file)
     npm ci || { err "npm ci failed for $CURRENT_BRANCH"; exit 1; }
-    # Always update Hugo modules and install dependencies before building
-    npm run hugo -- mod get -u || { err "hugo mod get -u failed for $CURRENT_BRANCH"; exit 1; }
-    npm run hugo -- mod tidy || { err "hugo mod tidy failed for $CURRENT_BRANCH"; exit 1; }
+
+    # Update Hugo modules for "dev" version. In case of errors restore backup of versions.json and exit
+    update_modules_for_version "$VERSION" || { [ -n "$TEMP_BACKUP" ] && mv "$TEMP_BACKUP" data/versions.json; exit 1; }
     
     # Execute Hugo build with final base URL
     npm run build -- --destination "$OUTDIR" --baseURL "$FINAL_BASE_URL" || { 
@@ -286,17 +315,19 @@ for VERSION in $VERSIONS; do
 
   # Optimization: reuse central node_modules if package-lock.json is identical
   if cmp -s package-lock.json ../../package-lock.json; then
-    info "package-lock.json is identical, creating symlink to central node_modules."
-    ln -s ../../node_modules ./node_modules
+    if [ -d ../../node_modules ]; then
+      info "package-lock.json is identical, creating symlink to central node_modules."
+      ln -s ../../node_modules ./node_modules
+    else
+      info "Central node_modules not present yet; installing dependencies in worktree."
+      npm ci || { err "npm ci failed for $BRANCH"; popd >/dev/null; exit 1; }
+    fi
   else
-    # Make npm clean install (using the package-lock.json file)
     info "package-lock.json differs from central version. Installing separate dependencies for this version."
     npm ci || { err "npm ci failed for $BRANCH"; popd >/dev/null; exit 1; }
   fi
-
-  # Always update Hugo modules before building
-  npm run hugo -- mod get -u || { err "hugo mod get -u failed for $BRANCH"; popd >/dev/null; exit 1; }
-  npm run hugo -- mod tidy || { err "hugo mod tidy failed for $BRANCH"; popd >/dev/null; exit 1; }
+  # Update Hugo Modules for "dev" version
+  update_modules_for_version "$VERSION" || { popd >/dev/null; exit 1; }
 
   # Build  site for this version using final base URL
   npm run build -- --destination "../../$OUTDIR" --baseURL "$FINAL_BASE_URL" || { err "npm run build failed for $BRANCH"; popd >/dev/null; exit 1; }

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,5 @@ module github.com/open-component-model/ocm-website
 go 1.25.0
 
 require (
-	ocm.software/open-component-model/cli v0.0.0-20250814075747-2664ef1f2f17 // indirect
+	ocm.software/open-component-model/cli v0.0.0-20250923093935-2a2e32661c39 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-ocm.software/open-component-model/cli v0.0.0-20250814075747-2664ef1f2f17 h1:EJFCUukwpipz3wmEq9rQ5p3D5rITX6AxoCDlFpm/mVM=
-ocm.software/open-component-model/cli v0.0.0-20250814075747-2664ef1f2f17/go.mod h1:W4fW+AVEDUh5UdiGS274S4kAm0/u8VKKDZYI2yx+FcU=
+ocm.software/open-component-model/cli v0.0.0-20250923093935-2a2e32661c39 h1:sZftra6w7htu6DohMbr3J2XUwapYr/yewbgkCBloCT4=
+ocm.software/open-component-model/cli v0.0.0-20250923093935-2a2e32661c39/go.mod h1:T57RDnv+7ltwAzIZg7I0h2CDliXOtfbxlKUl4vExQAU=


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Updates of the Hugo modules should a) only happen in the "dev" version and b) only be done for the configured modules, not all (avoid using `hugo mod get -u`)