### PR TITLE
chore: remove displaying release version from "dev" version of website

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -19,9 +19,11 @@
 
       <p class="text-default leader-open-source-text">
         {{ .Params.leader_open_source_text }}
+        {{ if ne site.Params.doks.docsVersion "dev" }}
         <a href="https://github.com/open-component-model/ocm/releases/tag/{{ .Site.Params.latest_version }}" class="text-link">
           GitHub {{ .Site.Params.latest_version }}
         </a>
+        {{ end }}
       </p>
       {{ .Content }}
       <p class="mb-1">


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
remove displaying release version from "dev" version of website as this is only meaningful for non "dev" versions.