### PR TITLE
chore: change types to k8s-style Upper Camel Case

### DIFF
--- a/content/docs/concepts/component-identity.md
+++ b/content/docs/concepts/component-identity.md
@@ -142,7 +142,7 @@ For more details, see [Artifact Types](https://github.com/open-component-model/o
 
 Access specifications decouple an artifact's identity from its storage location. The `access.type` field determines how to retrieve the artifact, while the remaining fields provide the location-specific details.
 
-The same artifact type can be accessed through different access specifications. For example, an `ociImage` could be stored in an OCI registry (`ociArtifact`) or bundled into a CTF archive (`localBlob`).
+The same artifact type can be accessed through different access specifications. For example, an `ociImage` could be stored in an OCI registry (`OCIImage/v1`) or bundled into a CTF archive (`LocalBlob/v1`).
 
 For available access types and their fields, see [Access Specification]({{< relref "docs/reference/component-descriptor.md" >}}#access-specification) and [Input and Access Types]({{< relref "docs/reference/input-and-access-types.md" >}}).
 

--- a/content/docs/concepts/signing-and-verification-concept.md
+++ b/content/docs/concepts/signing-and-verification-concept.md
@@ -132,7 +132,7 @@ component:
       version: 1.0.0
       relation: local
       access:                          # NOT included in signature
-        type: localBlob
+        type: LocalBlob/v1
         localReference: sha256:70a257...
         mediaType: text/plain; charset=utf-8
       digest:                          # Included in signature
@@ -144,7 +144,7 @@ component:
       version: 1.0.0
       relation: external
       access:                          # NOT included in signature
-        type: ociArtifact
+        type: OCIImage/v1
         imageReference: ghcr.io/stefanprodan/podinfo:6.9.1@sha256:262578cd...
       digest:                          # Included in signature
         hashAlgorithm: SHA-256

--- a/content/docs/getting-started/create-component-version.md
+++ b/content/docs/getting-started/create-component-version.md
@@ -83,13 +83,13 @@ components:
     - name: mylocalfile
       type: blob
       input: # Embed by value
-        type: file/v1
+        type: File/v1
         path: ./my-local-resource.txt
     - name: image
       type: ociImage
       version: 1.0.0
       access: # Reference externally
-        type: ociArtifact
+        type: OCIImage/v1
         imageReference: ghcr.io/stefanprodan/podinfo:6.9.1
 ```
 
@@ -117,7 +117,7 @@ resources:
   - name: config
     type: blob
     input:
-      type: file
+      type: File/v1
       path: ./config.yaml
 ```
 
@@ -133,7 +133,7 @@ resources:
     type: ociImage
     version: 1.0.0
     access:
-      type: ociArtifact
+      type: OCIImage/v1
       imageReference: ghcr.io/myorg/backend:v1.0.0
 ```
 
@@ -149,7 +149,7 @@ resources:
     type: helmChart
     version: 1.0.0
     access:
-      type: ociArtifact
+      type: OCIImage/v1
       imageReference: ghcr.io/myorg/charts/myapp:1.0.0
 ```
 
@@ -160,7 +160,7 @@ resources:
   - name: chart
     type: helmChart
     input:
-      type: helm
+      type: Helm/v1
       path: ./charts/myapp
 ```
 {{< /tab >}}
@@ -173,7 +173,7 @@ resources:
   - name: manifests
     type: blob
     input:
-      type: dir
+      type: Dir/v1
       path: ./kubernetes/
       compress: true
 ```
@@ -301,7 +301,7 @@ component:
   - access:
       localReference: sha256:70a2577d7b649574cbbba99a2f2ebdf27904a4abf80c9729923ee67ea8d2d9d8
       mediaType: text/plain; charset=utf-8
-      type: localBlob/v1
+      type: LocalBlob/v1
     digest:
       hashAlgorithm: SHA-256
       normalisationAlgorithm: genericBlobDigest/v1
@@ -312,7 +312,7 @@ component:
     version: 1.0.0
   - access:
       imageReference: ghcr.io/stefanprodan/podinfo:6.9.1@sha256:262578cde928d5c9eba3bce079976444f624c13ed0afb741d90d5423877496cb
-      type: ociArtifact
+      type: OCIImage/v1
     digest:
       hashAlgorithm: SHA-256
       normalisationAlgorithm: genericBlobDigest/v1
@@ -401,14 +401,14 @@ component:
   - access:
       localReference: sha256:70a2577d7b649574cbbba99a2f2ebdf27904a4abf80c9729923ee67ea8d2d9d8
       mediaType: text/plain; charset=utf-8
-      type: localBlob/v1
+      type: LocalBlob/v1
     name: mylocalfile
     relation: local
     type: blob
     version: 1.0.0
   - access:
       imageReference: ghcr.io/stefanprodan/podinfo:6.9.1@sha256:262578cde928d5c9eba3bce079976444f624c13ed0afb741d90d5423877496cb
-      type: ociArtifact
+      type: OCIImage/v1
     name: image
     relation: external
     type: ociImage

--- a/content/docs/getting-started/deploy-helm-chart.md
+++ b/content/docs/getting-started/deploy-helm-chart.md
@@ -62,7 +62,7 @@ components:
         type: helmChart
         version: 1.0.0
         access:
-          type: ociArtifact
+          type: OCIImage/v1
           imageReference: "ghcr.io/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a"
 ```
 

--- a/content/docs/how-to/container-image-usage.md
+++ b/content/docs/how-to/container-image-usage.md
@@ -47,7 +47,7 @@ This How-To will show you how to use the OCM CLI container image to create and g
         type: ociImage
         version: 1.0.0
         access:
-          type: ociArtifact
+          type: OCIImage/v1
           imageReference: ghcr.io/stefanprodan/podinfo:6.7.1
    EOF
    ```
@@ -139,7 +139,7 @@ This How-To will show you how to use the OCM CLI container image to create and g
        resources:
        - access:
            imageReference: ghcr.io/stefanprodan/podinfo:6.7.1@sha256:862ca45e61b32392f7941a1bdfdbe5ff8b6899070135f1bdca1c287d0057fc94
-           type: ociArtifact
+           type: OCIImage/v1
          digest:
            hashAlgorithm: SHA-256
            normalisationAlgorithm: genericBlobDigest/v1

--- a/content/docs/how-to/download-resources-from-component-versions.md
+++ b/content/docs/how-to/download-resources-from-component-versions.md
@@ -69,7 +69,7 @@ We're interested in the `chart` resource, which is a Helm chart stored as OCI ar
     resources:
       - access:
           imageReference: ghcr.io/stefanprodan/podinfo:6.8.0
-          type: ociArtifact
+          type: OCIImage/v1
         digest:
           hashAlgorithm: SHA-256
           normalisationAlgorithm: ociArtifactDigest/v1
@@ -80,7 +80,7 @@ We're interested in the `chart` resource, which is a Helm chart stored as OCI ar
         version: 6.8.0
       - access:
           imageReference: ghcr.io/stefanprodan/charts/podinfo:6.8.0
-          type: ociArtifact
+          type: OCIImage/v1
         digest:
           hashAlgorithm: SHA-256
           normalisationAlgorithm: ociArtifactDigest/v1

--- a/content/docs/how-to/transfer-helm-charts.md
+++ b/content/docs/how-to/transfer-helm-charts.md
@@ -47,7 +47,7 @@ components:
         access:
           type: Helm/v1
           helmRepository: https://charts.example.com
-          helmChart: my-chart-1.0.0.tgz
+          helmChart: my-chart:1.0.0
 ```
 
 Add the component version to a CTF archive:

--- a/content/docs/how-to/transfer-helm-charts.md
+++ b/content/docs/how-to/transfer-helm-charts.md
@@ -7,7 +7,7 @@ toc: true
 
 ## Goal
 
-Transfer a component version that contains a Helm chart resource sourced from a **Helm repository** (type `helmChart` with `helm/v1` access)
+Transfer a component version that contains a Helm chart resource sourced from a **Helm repository** (type `helmChart` with `Helm/v1` access)
 to an OCI registry. This guide does not cover charts that are already stored as OCI artifacts.
 
 ## Prerequisites
@@ -21,7 +21,7 @@ to an OCI registry. This guide does not cover charts that are already stored as 
 {{< steps >}}
 
 {{<callout context="note" title="Helm charts stored as ociImage" icon="outline/info-circle">}}
-If your existing component version contains a Helm chart stored as an `ociImage` resource rather than a `helmChart` with `helm/v1` access, you need to
+If your existing component version contains a Helm chart stored as an `ociImage` resource rather than a `helmChart` with `Helm/v1` access, you need to
 create a new component version using the `helmChart` type as shown below. This guide only covers the transfer of Helm charts sourced from Helm
 repositories.
 {{< /callout >}}
@@ -30,7 +30,7 @@ repositories.
 
 ### Create a component version with a Helm chart resource
 
-If you already have a component version containing a Helm chart with `helm/v1` access, skip to the next step.
+If you already have a component version containing a Helm chart with `Helm/v1` access, skip to the next step.
 
 Create a `constructor.yaml` that references a chart from a Helm repository:
 
@@ -45,7 +45,7 @@ components:
         version: 1.0.0
         type: helmChart
         access:
-          type: helm/v1
+          type: Helm/v1
           helmRepository: https://charts.example.com
           helmChart: my-chart-1.0.0.tgz
 ```
@@ -61,7 +61,7 @@ ocm add cv --repository ctf::<path/to/archive> \
 {{< /step >}}
 
 {{<callout context="caution" title="Why --skip-reference-digest-processing?" icon="outline/alert-triangle">}}
-The `--skip-reference-digest-processing` flag is required because the `helm/v1` access type currently cannot be fully resolved during `add cv`.
+The `--skip-reference-digest-processing` flag is required because the `Helm/v1` access type currently cannot be fully resolved during `add cv`.
 The chart is not downloaded at this stage, so digest calculation is not possible. The digests are computed later during transfer when the chart is
 actually fetched.
 Full Helm support is being tracked as a future feature in [ocm-project#911](https://github.com/open-component-model/ocm-project/issues/911).
@@ -108,7 +108,7 @@ resources:
   - name: my-chart
     type: helmChart
     access:
-      type: ociArtifact/v1
+      type: OCIImage/v1
       imageReference: ghcr.io/my-org/charts/my-chart:1.0.0
 ```
 

--- a/content/docs/reference/input-and-access-types.md
+++ b/content/docs/reference/input-and-access-types.md
@@ -16,7 +16,7 @@ A resource must have exactly one of `input` or `access`. See the [Component Cons
 
 ## Input Types
 
-### `dir/v1`
+### `Dir/v1`
 
 Embeds a directory as a tar archive.
 
@@ -36,13 +36,13 @@ resources:
 - name: deploy-manifests
   type: blob
   input:
-    type: dir/v1
+    type: Dir/v1
     path: ./deploy
     compress: true
     reproducible: true
 ```
 
-### `file/v1`
+### `File/v1`
 
 Embeds a single file.
 
@@ -57,12 +57,12 @@ resources:
 - name: config
   type: blob
   input:
-    type: file/v1
+    type: File/v1
     path: ./config.yaml
     mediaType: application/yaml
 ```
 
-### `helm/v1`
+### `Helm/v1`
 
 Embeds a Helm chart from the local filesystem or a remote repository. Exactly one of `path` or `helmRepository` must be specified.
 
@@ -78,7 +78,7 @@ resources:
 - name: my-chart
   type: helmChart
   input:
-    type: helm/v1
+    type: Helm/v1
     path: ./charts/myapp
     repository: charts/myapp:1.0.0
 ---
@@ -87,7 +87,7 @@ resources:
 - name: ingress-chart
   type: helmChart
   input:
-    type: helm/v1
+    type: Helm/v1
     helmRepository: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.14.0/ingress-nginx-4.14.0.tgz
 ---
 # Remote chart (OCI)
@@ -95,16 +95,16 @@ resources:
 - name: podinfo-chart
   type: helmChart
   input:
-    type: helm/v1
+    type: Helm/v1
     helmRepository: oci://ghcr.io/stefanprodan/charts/podinfo:6.9.1
     repository: charts/podinfo:6.9.1
 ```
 
 {{< callout type="info" >}}
-The deprecated aliases `helm` and `Helm` are still accepted but `helm/v1` is the preferred form.
+The deprecated aliases `helm` and `helm/v1` are still accepted but `Helm/v1` is the preferred form.
 {{< /callout >}}
 
-### `utf8/v1`
+### `UTF8/v1`
 
 Embeds inline text or structured data. Exactly one of `text`, `json`, `formattedJson`, or `yaml` must be specified.
 
@@ -121,7 +121,7 @@ resources:
 - name: config-data
   type: blob
   input:
-    type: utf8/v1
+    type: UTF8/v1
     json:
       replicas: 3
       env: production
@@ -148,7 +148,7 @@ resources:
     imageReference: ghcr.io/acme/myapp:1.0.0
 ```
 
-### `localBlob/v1`
+### `LocalBlob/v1`
 
 References content stored alongside the component descriptor in the same repository. Typically created automatically when using input types.
 
@@ -165,7 +165,7 @@ resources:
   type: blob
   relation: local
   access:
-    type: localBlob/v1
+    type: LocalBlob/v1
     localReference: sha256:57563cb4a3e5c06a22c95aaa445...
     mediaType: application/octet-stream
 ```

--- a/content/docs/tutorials/advanced-component-constructor.md
+++ b/content/docs/tutorials/advanced-component-constructor.md
@@ -16,7 +16,7 @@ In this tutorial, we will create a small but realistic product. By the end, you 
 
 {{< callout context="note" title="What You'll Learn" >}}
 
-- Defining multiple components with `helm/v1`, `utf8/v1`, and `dir/v1` input types
+- Defining multiple components with `Helm/v1`, `UTF8/v1`, and `Dir/v1` input types
 - Wiring components together with `componentReferences`
 - Nesting references into a multi-level product hierarchy
 - Attaching labels to components
@@ -89,7 +89,7 @@ components:
     - name: chart
       type: helmChart
       input:
-        type: helm/v1
+        type: Helm/v1
         helmRepository: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.14.0/ingress-nginx-4.14.0.tgz
     - name: image
       type: ociImage
@@ -107,7 +107,7 @@ components:
     - name: manifests
       type: blob
       input:
-        type: utf8/v1
+        type: UTF8/v1
         yaml:
           apiVersion: v1
           kind: Service
@@ -146,8 +146,8 @@ EOF
 
 A few things to notice:
 
-- [**`helm/v1`**]({{< relref "docs/reference/input-and-access-types.md#helmv1" >}}) input type fetches a Helm chart from a remote repository and embeds it into the archive at creation time.
-- [**`utf8/v1`**]({{< relref "docs/reference/input-and-access-types.md#utf8v1" >}}) input type lets you embed small inline configuration directly in the constructor file.
+- [**`Helm/v1`**]({{< relref "docs/reference/input-and-access-types.md#helmv1" >}}) input type fetches a Helm chart from a remote repository and embeds it into the archive at creation time.
+- [**`UTF8/v1`**]({{< relref "docs/reference/input-and-access-types.md#utf8v1" >}}) input type lets you embed small inline configuration directly in the constructor file.
 - [**`componentReferences`**]({{< relref "docs/reference/component-constructor.md#component-references" >}}) creates a directed edge in the component graph. The product-web component itself has no resources — it is purely an aggregator.
 
 {{< /step >}}
@@ -185,7 +185,7 @@ cat >> component-constructor.yaml << 'EOF'
     - name: migrations
       type: blob
       input:
-        type: dir/v1
+        type: Dir/v1
         path: ./db
         compress: true
     - name: database
@@ -197,7 +197,7 @@ cat >> component-constructor.yaml << 'EOF'
 EOF
 ```
 
-The [**`dir/v1`**]({{< relref "docs/reference/input-and-access-types.md#dirv1" >}}) input type embeds an entire directory as a compressed archive — here used for SQL migration scripts.
+The [**`Dir/v1`**]({{< relref "docs/reference/input-and-access-types.md#dirv1" >}}) input type embeds an entire directory as a compressed archive — here used for SQL migration scripts.
 
 {{< /step >}}
 
@@ -259,7 +259,7 @@ components:
     - name: chart
       type: helmChart
       input:
-        type: helm/v1
+        type: Helm/v1
         helmRepository: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.14.0/ingress-nginx-4.14.0.tgz
     - name: image
       type: ociImage
@@ -277,7 +277,7 @@ components:
     - name: manifests
       type: blob
       input:
-        type: utf8/v1
+        type: UTF8/v1
         yaml:
           apiVersion: v1
           kind: Service
@@ -321,7 +321,7 @@ components:
     - name: migrations
       type: blob
       input:
-        type: dir/v1
+        type: Dir/v1
         path: ./db
         compress: true
     - name: database
@@ -420,7 +420,7 @@ ocm get cv my-product//ocm.software/tutorials/frontend:1.5.0 -o yaml
     - access:
         localReference: sha256:...
         mediaType: application/vnd.oci.image.manifest.v1+json
-        type: localBlob/v1
+        type: LocalBlob/v1
       digest:
         hashAlgorithm: SHA-256
         normalisationAlgorithm: genericBlobDigest/v1
@@ -475,7 +475,7 @@ components:
     - name: chart
       type: helmChart
       input:
-        type: helm/v1
+        type: Helm/v1
         helmRepository: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.14.0/ingress-nginx-4.14.0.tgz
     - name: image
       type: ociImage
@@ -495,7 +495,7 @@ components:
     - name: manifests
       type: blob
       input:
-        type: utf8/v1
+        type: UTF8/v1
         yaml:
           apiVersion: v1
           kind: Service
@@ -525,7 +525,7 @@ components:
     - name: migrations
       type: blob
       input:
-        type: dir/v1
+        type: Dir/v1
         path: ./db
         compress: true
     - name: database
@@ -601,7 +601,7 @@ Undefined variables expand to empty strings, which will fail schema validation �
 
 ## What you've learned
 
-- **Multiple input types** — `dir/v1` for directories, `utf8/v1` for inline content, and `helm/v1` for remote Helm charts
+- **Multiple input types** — `Dir/v1` for directories, `UTF8/v1` for inline content, and `Helm/v1` for remote Helm charts
 - **Component references** — directed edges that compose products from independently versioned parts
 - **Multi-level nesting** — platform → product → component hierarchies, all in one constructor file
 - **Labels** — attaching metadata to components, optionally included in signing

--- a/content/docs/tutorials/configure-resolvers.md
+++ b/content/docs/tutorials/configure-resolvers.md
@@ -113,7 +113,7 @@ components:
         version: "1.0.0"
         type: plainText
         input:
-          type: utf8
+          type: UTF8/v1
           text: "backend service configuration"
 ```
 
@@ -152,7 +152,7 @@ components:
         version: "1.0.0"
         type: plainText
         input:
-          type: utf8
+          type: UTF8/v1
           text: "frontend service configuration"
 ```
 
@@ -199,7 +199,7 @@ components:
         version: "1.0.0"
         type: plainText
         input:
-          type: utf8
+          type: UTF8/v1
           text: "app deployment configuration"
 ```
 

--- a/content/docs/tutorials/deploy-helm-chart-bootstrap.md
+++ b/content/docs/tutorials/deploy-helm-chart-bootstrap.md
@@ -30,7 +30,7 @@ with the same OCM component. Additionally, it shows how to **localize** a Helm c
 Helm chart. It is a two-step process:
 
 1. When an OCM component and its resources are transferred to another registry, **referential resources** can
-potentially update their reference to the new location. For instance, a resource with an access type `ociArtifact`
+potentially update their reference to the new location. For instance, a resource with an access type `OCIImage/v1`
 will update its image reference in the component descriptor to the new registry location, if the OCM transfer is done
 with the flag `--copy-resources`.
 1. However, the deployment using the image is not aware of this change. Accordingly, we need to insert the new image
@@ -179,19 +179,19 @@ components:
         type: helmChart
         version: "1.0.0"
         access:
-          type: ociArtifact
+          type: OCIImage/v1
           imageReference: "ghcr.io/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a"
       - name: image-resource
         type: ociArtifact
         version: "1.0.0"
         access:
-          type: ociRegistry
+          type: OCIImage/v1
           imageReference: "ghcr.io/stefanprodan/podinfo:6.9.1@sha256:262578cde928d5c9eba3bce079976444f624c13ed0afb741d90d5423877496cb"
       - name: resource-graph-definition
         type: blob
         version: "1.0.0"
         input:
-          type: file
+          type: File/v1
           path: ./resourceGraphDefinition.yaml
 ```
 
@@ -350,7 +350,7 @@ ocm get componentversion ghcr.io/<your-namespace>//ocm.software/ocm-k8s-toolkit/
 # Output is truncated for brevity
 - access:
     imageReference: ghcr.io/<your-namespace>/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a
-    type: ociArtifact
+    type: OCIImage/v1
   digest:
     ...
   name: helm-resource
@@ -359,7 +359,7 @@ ocm get componentversion ghcr.io/<your-namespace>//ocm.software/ocm-k8s-toolkit/
   version: 1.0.0
 - access:
     imageReference: ghcr.io/<your-namespace>/stefanprodan/podinfo:6.9.1@sha256:262578cde928d5c9eba3bce079976444f624c13ed0afb741d90d5423877496cb
-    type: ociArtifact
+    type: OCIImage/v1
   digest:
     ...
   name: image-resource
@@ -369,7 +369,7 @@ ocm get componentversion ghcr.io/<your-namespace>//ocm.software/ocm-k8s-toolkit/
 - access:
     localReference: sha256:ed5252ff70bfe93e763ff6afeafe8dafd14c128981e4ae1472e35afc3ebe7a63
     mediaType: application/octet-stream
-    type: localBlob
+    type: LocalBlob/v1
   digest:
      ...
   name: resource-graph-definition


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
We want to consistently use k8s UpperCamelCase/v1 typing style as the default notation for input and access types.

#### Which issue(s) this PR is related to

Related to https://github.com/open-component-model/ocm-project/issues/962


#### Type of content
- [x] Tutorial (`getting-started/` or `tutorials/`)
- [x] How-to Guide (`how-to/`)
- [ ] Explanation / Concept (`concepts/`)
- [x] Reference (`reference/`)

#### Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/open-component-model/ocm-website/blob/main/CONTRIBUTING.md)
- [ ] All commands/code snippets are tested and can be copy-pasted