### PR TITLE
docs: update schema URLs in YAML examples for component constructor

### DIFF
--- a/content/docs/getting-started/create-component-version.md
+++ b/content/docs/getting-started/create-component-version.md
@@ -71,7 +71,7 @@ echo "My first local Resource for an OCM component" > my-local-resource.txt
 Create a `component-constructor.yaml` file that describes your component and its resources:
 
 ```yaml
-# yaml-language-server: $schema=https://ocm.software/schemas/configuration-schema.yaml
+# yaml-language-server: $schema=https://ocm.software/latest/schemas/bindings/go/constructor/schema-2020-12.json
 components:
 - name: github.com/acme.org/helloworld # Must at least be a DNS domain as per RFC 1123.
   version: 1.0.0 # Version conforming to SemVer 2.0.

--- a/content/docs/how-to/model-products.md
+++ b/content/docs/how-to/model-products.md
@@ -35,7 +35,7 @@ Each service gets its own component. Create a single `component-constructor.yaml
 
 ```shell
 cat > component-constructor.yaml << 'EOF'
-# yaml-language-server: $schema=https://ocm.software/schemas/configuration-schema.yaml
+# yaml-language-server: $schema=https://ocm.software/latest/schemas/bindings/go/constructor/schema-2020-12.json
 components:
 
 # -- Backend service
@@ -182,7 +182,7 @@ Say the backend team releases a patch (`3.1.0` → `3.2.0`). Replace the constru
 
 ```shell
 cat > component-constructor.yaml << 'EOF'
-# yaml-language-server: $schema=https://ocm.software/schemas/configuration-schema.yaml
+# yaml-language-server: $schema=https://ocm.software/latest/schemas/bindings/go/constructor/schema-2020-12.json
 components:
 
 # -- Backend service (bumped)

--- a/content/docs/tutorials/advanced-component-constructor.md
+++ b/content/docs/tutorials/advanced-component-constructor.md
@@ -88,7 +88,7 @@ Create `component-constructor.yaml`:
 
 ```shell
 cat > component-constructor.yaml << 'EOF'
-# yaml-language-server: $schema=https://ocm.software/schemas/configuration-schema.yaml
+# yaml-language-server: $schema=https://ocm.software/latest/schemas/bindings/go/constructor/schema-2020-12.json
 components:
 
 # ── Frontend ────────────────────────────────────────────────────
@@ -259,7 +259,7 @@ With all five components defined in a single constructor file, you can now creat
   <summary>Complete <code>component-constructor.yaml</code></summary>
 
 ```yaml
-# yaml-language-server: $schema=https://ocm.software/schemas/configuration-schema.yaml
+# yaml-language-server: $schema=https://ocm.software/latest/schemas/bindings/go/constructor/schema-2020-12.json
 components:
 
 # ── Frontend ────────────────────────────────────────────────────
@@ -470,7 +470,7 @@ In practice you rarely hard-code version numbers — they are typically provided
 
 ```shell
 cat > component-constructor.yaml << 'EOF'
-# yaml-language-server: $schema=https://ocm.software/schemas/configuration-schema.yaml
+# yaml-language-server: $schema=https://ocm.software/latest/schemas/bindings/go/constructor/schema-2020-12.json
 components:
 
 - name: ocm.software/tutorials/frontend

--- a/content_templates/template-tutorial.md
+++ b/content_templates/template-tutorial.md
@@ -94,7 +94,7 @@ touch component-constructor.yaml
 Create and save this content to `component-constructor.yaml`:
 
 ```yaml
-# yaml-language-server: $schema=https://ocm.software/schemas/configuration-schema.yaml
+# yaml-language-server: $schema=https://ocm.software/latest/schemas/bindings/go/constructor/schema-2020-12.json
 components:
 - name: github.com/acme.org/helloworld
   version: 1.0.0


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Replaced outdated schema with a hardcoded set of types (access and input) but also proper auto-complete support with the updated schema from the monorepo multiple documentation files for improved accuracy and compatibility.

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->
Contributes to https://github.com/open-component-model/ocm-project/issues/961

#### Type of content
<!--
Which section does this PR target? See CONTRIBUTING.md for guidance.
-->
- [ ] Tutorial (`getting-started/` or `tutorials/`)
- [ ] How-to Guide (`how-to/`)
- [ ] Explanation / Concept (`concepts/`)
- [ ] Reference (`reference/`)
- [x] Other (infrastructure, config, fixes)

#### Checklist

- [x] I have read and followed the [Contributing Guide](https://github.com/open-component-model/ocm-website/blob/main/CONTRIBUTING.md)
- [ ] All commands/code snippets are tested and can be copy-pasted
