### PR TITLE
docs: update migration section to correct version names and defaults

### DIFF
--- a/content/blog/ocm_v2_announcement.md
+++ b/content/blog/ocm_v2_announcement.md
@@ -241,8 +241,9 @@ The legacy OCM stack will be supported until at least **the end of 2026**. Exist
 
 The documentation site now serves two versions:
 
-- **Legacy** — documentation for the original OCM stack. This is currently the default.
-- **v2 docs** (currently labeled "dev") — documentation for the new stack you are reading about here.
+- **v1 docs** (labeled "legacy") — documentation for the original OCM stack.
+- **v2 docs** (currently labeled "latest") — documentation for the new stack 
+  you are reading about here. This is now the default.
 
 {{< callout context="tip" title="Migration should be affordable" >}}
 Both v1 and v2 implement the same [OCM Specification](https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/00-component-descriptor/v2.md), so component versions created with either stack are fully interoperable. Many CLI commands are cross-compatible and we made a deliberate effort to keep the `.ocmconfig` structure and command syntax consistent, so existing users and CI/CD pipelines should find the transition straightforward.

--- a/content_versioned/version-legacy/docs/tutorials/best-practices.md
+++ b/content_versioned/version-legacy/docs/tutorials/best-practices.md
@@ -30,7 +30,7 @@ This schema is available at [https://ocm.software/schemas/configuration-schema.y
 To use this schema in your IDE, you can add the following line to your component constructor file:
 
 ```yaml
-# yaml-language-server: $schema=https://ocm.software/schemas/configuration-schema.yaml
+# yaml-language-server: $schema=https://ocm.software/latest/schemas/bindings/go/constructor/schema-2020-12.json
 ```
 
 This line tells the YAML language server to use the OCM schema for validation and auto-completion.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Update blog post to updated version names and defaults. The current information is outdated.

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->

#### Type of content
<!--
Which section does this PR target? See CONTRIBUTING.md for guidance.
-->
- [ ] Tutorial (`getting-started/` or `tutorials/`)
- [ ] How-to Guide (`how-to/`)
- [ ] Explanation / Concept (`concepts/`)
- [ ] Reference (`reference/`)
- [ ] Other (infrastructure, config, fixes)

#### Checklist

- [ ] I have read and followed the [Contributing Guide](https://github.com/open-component-model/ocm-website/blob/main/CONTRIBUTING.md)
- [ ] All commands/code snippets are tested and can be copy-pasted
